### PR TITLE
Alternative build with Apache CXF

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 `winrm4j` is a project which enables Java applications to execute batch or PowerShell commands on a remote Windows server 
 using [WinRM](https://msdn.microsoft.com/en-us/library/aa384426(v=vs.85).aspx)
 
-The code is based on the Python project [pywinrm](https://github.com/diyan/pywinrm) and uses [jython](http://www.jython.org/)
-to make the Python classes accessible to Java.
-
 You can download the latest binaries [here](http://mvnrepository.com/artifact/io.cloudsoft.windows/winrm4j), which also gives the details
 for adding winrm4j as a dependency to your project.
 
 If you wish to build the binaries yourself, you can clone this project, and build it using [Maven](https://maven.apache.org/):
 
 `mvn clean install`
+
+To build using the Apache CXF project tools use
+
+`mvn clean install -Djax-ws-cxf`
 
 Before connecting to a Windows server, you will need to ensure that the server is accessible and has been configured to allow
 unencrypted WinRM connections over http. The following batch script will configure WinRM and open port 5985 (the default WinRM
@@ -32,27 +33,15 @@ netsh advfirewall firewall add rule name=RDP dir=in protocol=tcp localport=3389 
 netsh advfirewall firewall add rule name=WinRM dir=in protocol=tcp localport=5985 action=allow profile=any
 ```
 
-To test connectivity, you can install [Python](https://www.python.org/) and [pywinrm](https://pypi.python.org/pypi/pywinrm) on you development machine,
-then use pywinrm directly in a Python console:
-
-``` python
-import winrm
-s = winrm.Session('my.windows.server.com', auth=('Administrator', 'mypassword'))
-r = s.run_ps("ls")
-r.std_out
-r.std_err
-r.status_code
-```
-
-To use winrm4j in Java code, you first create a `Session` object via the `WinRMFactory` class. The session object exposes the methods
-`run_cmd` and `run_ps`, which can be used to execute batch or PowerShell statements respectively.
+To use winrm4j in Java code, you first create a `WinRmTool` object via the static `connect` method. It exposes the methods
+`executeScript` and `executePs`, which can be used to execute batch or PowerShell statements respectively.
 
 ``` java
-Session session = WinRMFactory.INSTANCE.createSession("my.windows.server.com", "Administrator", "mypassword");
+WinRMTool winrm = WinRmTool.connect("my.windows.server.com", "Administrator", "password");
 
-Response response = session.run_cmd("dir C:\\");
+WinRmToolResponse response = winrm.executeScript(ImmutableList.of("dir C:\\"));
 System.out.println(response.getStdOut());
 
-response = session.run_ps("ls C:\\");
+response = session.executePs(ImmutableList.of("ls C:\\"));
 System.out.println(response.getStdOut());
 ```

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -96,31 +96,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jvnet.jax-ws-commons</groupId>
-        <artifactId>jaxws-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>import-wsdl</id>
-            <goals>
-              <goal>wsimport</goal>
-            </goals>
-            <configuration>
-              <extension>true</extension>
-              <keep>true</keep>
-              <xnocompile>true</xnocompile>
-              <bindingFiles>
-                <bindingFile>bindings.xml</bindingFile>
-              </bindingFiles>
-              <wsdlDirectory>${project.build.directory}/winrm4j-service-wsdl/META-INF/wsdl</wsdlDirectory>
-              <args>
-                <arg>-clientjar</arg>
-                <arg>wsdl.jar</arg>
-              </args>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -153,4 +128,81 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jax-ws-ri</id>
+      <activation>
+        <property>
+            <name>!jax-ws-cxf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jvnet.jax-ws-commons</groupId>
+            <artifactId>jaxws-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>import-wsdl</id>
+                <goals>
+                  <goal>wsimport</goal>
+                </goals>
+                <configuration>
+                  <extension>true</extension>
+                  <keep>true</keep>
+                  <xnocompile>true</xnocompile>
+                  <bindingFiles>
+                    <bindingFile>bindings.xml</bindingFile>
+                  </bindingFiles>
+                  <wsdlDirectory>${project.build.directory}/winrm4j-service-wsdl/META-INF/wsdl</wsdlDirectory>
+                  <args>
+                    <arg>-clientjar</arg>
+                    <arg>wsdl.jar</arg>
+                  </args>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jax-ws-cxf</id>
+      <activation>
+        <property>
+            <name>jax-ws-cxf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-codegen-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>import-wsdl</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>wsdl2java</goal>
+                </goals>
+                <configuration>
+                  <wsdlOptions>
+                      <wsdlOption>
+                          <wsdl>${project.build.directory}/winrm4j-service-wsdl/META-INF/wsdl/WinRmService.wsdl</wsdl>
+                          <bindingFiles><bindingFile>${basedir}/src/jaxws/bindings.xml</bindingFile></bindingFiles>
+                          <extraargs>
+                              <extraarg>-verbose</extraarg>
+                          </extraargs>
+                      </wsdlOption>
+                  </wsdlOptions>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/client/src/jaxws/bindings.xml
+++ b/client/src/jaxws/bindings.xml
@@ -9,19 +9,19 @@
   <jaxws:enableAsyncMapping>false</jaxws:enableAsyncMapping>
 
   <jaxws:bindings
-    node="//wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.microsoft.com/wbem/wsman/1/windows/shell']">
+    node="wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.microsoft.com/wbem/wsman/1/windows/shell']">
     <jaxb:schemaBindings>
       <jaxb:package name="io.cloudsoft.winrm4j.client.shell" />
     </jaxb:schemaBindings>
   </jaxws:bindings>
   <jaxws:bindings
-    node="//wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd']">
+    node="wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd']">
     <jaxb:schemaBindings>
       <jaxb:package name="io.cloudsoft.winrm4j.client.wsman" />
     </jaxb:schemaBindings>
   </jaxws:bindings>
   <jaxws:bindings
-    node="//wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.xmlsoap.org/ws/2004/09/transfer']">
+    node="wsdl:definitions/wsdl:types/xs:schema[@targetNamespace='http://schemas.xmlsoap.org/ws/2004/09/transfer']">
     <jaxb:schemaBindings>
       <jaxb:package name="io.cloudsoft.winrm4j.client.transfer" />
     </jaxb:schemaBindings>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,16 @@
           <version>2.2</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-java2ws-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-codegen-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>1.10</version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -30,29 +30,6 @@
   </parent>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jvnet.jax-ws-commons</groupId>
-        <artifactId>jaxws-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-wsdl</id>
-            <goals>
-              <goal>wsgen</goal>
-            </goals>
-            <configuration>
-              <sei>io.cloudsoft.winrm4j.service.WinRm</sei>
-              <genWsdl>true</genWsdl>
-              <protocol>Xsoap1.2</protocol>
-              <inlineSchemas>true</inlineSchemas>
-              <extension>true</extension>
-              <keep>true</keep>
-              <xnocompile>true</xnocompile>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
     <pluginManagement>
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings 
@@ -84,4 +61,72 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jax-ws-ri</id>
+      <activation>
+        <property>
+            <name>!jax-ws-cxf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jvnet.jax-ws-commons</groupId>
+            <artifactId>jaxws-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-wsdl</id>
+                <goals>
+                  <goal>wsgen</goal>
+                </goals>
+                <configuration>
+                  <sei>io.cloudsoft.winrm4j.service.WinRm</sei>
+                  <genWsdl>true</genWsdl>
+                  <protocol>Xsoap1.2</protocol>
+                  <inlineSchemas>true</inlineSchemas>
+                  <extension>true</extension>
+                  <keep>true</keep>
+                  <xnocompile>true</xnocompile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jax-ws-cxf</id>
+      <activation>
+        <property>
+            <name>jax-ws-cxf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-java2ws-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-wsdl</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>java2ws</goal>
+                </goals>
+                <configuration>
+                  <className>io.cloudsoft.winrm4j.service.WinRm</className>
+                  <genWsdl>true</genWsdl>
+                  <soap12>true</soap12>
+                  <verbose>true</verbose>
+                  <outputFile>${project.build.directory}/classes/META-INF/wsdl/WinRmService.wsdl</outputFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/service/src/main/java/io/cloudsoft/winrm4j/service/shell/ReceiveResponse.java
+++ b/service/src/main/java/io/cloudsoft/winrm4j/service/shell/ReceiveResponse.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlType;
 
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "ReceiveResponse", propOrder = {
+@XmlType(name = "ReceiveResponse", namespace="http://schemas.microsoft.com/wbem/wsman/1/windows/shell", propOrder = {
     "stream",
     "commandState"
 })

--- a/service/src/main/java/io/cloudsoft/winrm4j/service/shell/SignalResponse.java
+++ b/service/src/main/java/io/cloudsoft/winrm4j/service/shell/SignalResponse.java
@@ -11,7 +11,7 @@ import org.w3c.dom.Element;
 
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "SignalResponse", propOrder = {
+@XmlType(name = "SignalResponse", namespace="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", propOrder = {
     "any"
 })
 public class SignalResponse {

--- a/service/src/main/java/io/cloudsoft/winrm4j/service/transfer/ResourceCreated.java
+++ b/service/src/main/java/io/cloudsoft/winrm4j/service/transfer/ResourceCreated.java
@@ -11,7 +11,7 @@ import org.w3c.dom.Element;
 
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "", propOrder = {
+@XmlType(name = "ResourceCreated", namespace="http://schemas.xmlsoap.org/ws/2004/09/transfer", propOrder = {
     "any"
 })
 public class ResourceCreated {


### PR DESCRIPTION
Pass -Djax-ws-cxf to build with Apache CXF. Note that this is compile time only dependency atm, at runtime still using `JAX-WS RI`.