### PR TITLE
Upgrade CXF, fixes concurrent http client errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <surefire.version>2.18.1</surefire.version>
     <testng.version>6.8.8</testng.version>
     <guava.version>17.0</guava.version>
-    <cxf.version>3.1.4</cxf.version>
+    <cxf.version>3.1.9</cxf.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
[DO NOT MERGE] until Brooklyn upgrades to CXF 3.1.9.

Upgrades to http client [4.5.2](http://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt) which fixes https://issues.apache.org/jira/browse/HTTPCLIENT-1715.

When executing `WinRmToolExecLiveTest.testToolConcurrentReuse()` I get the following error before the upgrade:

```
WARNING: Interceptor for {http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}WinRmService#{http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd}Create has thrown exception, unwinding now
java.lang.ArrayIndexOutOfBoundsException: ArrayIndexOutOfBoundsException invoking http://172.28.128.48:5985/wsman: 40
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.mapException(HTTPConduit.java:1376)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1365)
	at org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduit$AsyncWrappedOutputStream.close(AsyncHTTPConduit.java:415)
	at org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
	at org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:651)
	at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:62)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:308)
	at org.apache.cxf.endpoint.ClientImpl.doInvoke(ClientImpl.java:514)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:423)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:324)
	at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:277)
	at org.apache.cxf.frontend.ClientProxy.invokeSync(ClientProxy.java:96)
	at org.apache.cxf.jaxws.JaxWsClientProxy.invoke(JaxWsClientProxy.java:139)
	at com.sun.proxy.$Proxy50.create(Unknown Source)
	at io.cloudsoft.winrm4j.client.WinRmClient$4.call(WinRmClient.java:701)
	at io.cloudsoft.winrm4j.client.WinRmClient$4.call(WinRmClient.java:1)
	at io.cloudsoft.winrm4j.client.WinRmClient.winrmCallRetryConnFailure(WinRmClient.java:770)
	at io.cloudsoft.winrm4j.client.WinRmClient.doCreateService_3_InitializeClientAndService(WinRmClient.java:696)
	at io.cloudsoft.winrm4j.client.WinRmClient.doCreateServiceWithBean(WinRmClient.java:537)
	at io.cloudsoft.winrm4j.client.WinRmClient.createService(WinRmClient.java:443)
	at io.cloudsoft.winrm4j.client.WinRmClient.getService(WinRmClient.java:427)
	at io.cloudsoft.winrm4j.client.WinRmClient.command(WinRmClient.java:249)
	at io.cloudsoft.winrm4j.winrm.WinRmTool.executeCommand(WinRmTool.java:227)
	at io.cloudsoft.winrm4j.winrm.WinRmTool.executePs(WinRmTool.java:242)
	at io.cloudsoft.winrm4j.winrm.AbstractWinRmToolLiveTest$6.call(AbstractWinRmToolLiveTest.java:184)
	at io.cloudsoft.winrm4j.winrm.AbstractWinRmToolLiveTest$6.call(AbstractWinRmToolLiveTest.java:182)
	at io.cloudsoft.winrm4j.winrm.AbstractWinRmToolLiveTest.callWithRetries(AbstractWinRmToolLiveTest.java:197)
	at io.cloudsoft.winrm4j.winrm.AbstractWinRmToolLiveTest.executePs(AbstractWinRmToolLiveTest.java:182)
	at io.cloudsoft.winrm4j.winrm.WinRmToolExecLiveTest$1.call(WinRmToolExecLiveTest.java:423)
	at io.cloudsoft.winrm4j.winrm.WinRmToolExecLiveTest$1.call(WinRmToolExecLiveTest.java:418)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 40
	at org.apache.http.impl.auth.NTLMEngineImpl$NTLMMessage.addByte(NTLMEngineImpl.java:911)
	at org.apache.http.impl.auth.NTLMEngineImpl$NTLMMessage.addUShort(NTLMEngineImpl.java:933)
	at org.apache.http.impl.auth.NTLMEngineImpl$Type1Message.getResponse(NTLMEngineImpl.java:1032)
	at org.apache.http.impl.auth.NTLMEngineImpl.getType1Message(NTLMEngineImpl.java:148)
	at org.apache.http.impl.auth.NTLMEngineImpl.generateType1Msg(NTLMEngineImpl.java:1628)
	at org.apache.http.impl.auth.NTLMScheme.authenticate(NTLMScheme.java:139)
	at io.cloudsoft.winrm4j.client.ntlm.ApacheSpnegoScheme.authenticate(ApacheSpnegoScheme.java:21)
	at org.apache.http.impl.auth.AuthSchemeBase.authenticate(AuthSchemeBase.java:138)
	at org.apache.http.impl.auth.HttpAuthenticator.doAuth(HttpAuthenticator.java:239)
	at org.apache.http.impl.auth.HttpAuthenticator.generateAuthResponse(HttpAuthenticator.java:202)
	at org.apache.http.impl.nio.client.MainClientExec.generateRequest(MainClientExec.java:224)
	at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.generateRequest(DefaultClientExchangeHandlerImpl.java:130)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.requestReady(HttpAsyncRequestExecutor.java:176)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.connected(HttpAsyncRequestExecutor.java:127)
	at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:63)
	at org.apache.http.impl.nio.client.InternalIODispatch.onConnected(InternalIODispatch.java:39)
	at org.apache.http.impl.nio.reactor.AbstractIODispatch.connected(AbstractIODispatch.java:75)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.sessionCreated(BaseIOReactor.java:250)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processNewChannels(AbstractIOReactor.java:429)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:289)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:106)
	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:590)
	... 1 more
```