### PR TITLE
Strip Shell element from Create response

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -50,6 +50,18 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${mockwebserver.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-matchers</artifactId>
+      <version>${xmlunit.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/StripShellResponseHandler.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/StripShellResponseHandler.java
@@ -1,0 +1,59 @@
+package io.cloudsoft.winrm4j.client;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPEnvelope;
+import javax.xml.soap.SOAPException;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+
+public class StripShellResponseHandler implements SOAPHandler<SOAPMessageContext> {
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        boolean isResponse = Boolean.FALSE.equals(context.get (MessageContext.MESSAGE_OUTBOUND_PROPERTY));
+        if (isResponse) {
+            QName action = (QName) context.get(SOAPMessageContext.WSDL_OPERATION);
+            if ("Create".equals(action.getLocalPart())) {
+                Iterator<?> childIter = getBodyChildren(context);
+                while(childIter.hasNext()) {
+                    SOAPElement el = (SOAPElement) childIter.next();
+                    if ("Shell".equals(el.getLocalName())) {
+                        childIter.remove();
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private Iterator<?> getBodyChildren(SOAPMessageContext context) {
+        try {
+            SOAPEnvelope envelope = context.getMessage().getSOAPPart().getEnvelope();
+            SOAPBody body = envelope.getBody();
+            return body.getChildElements();
+        } catch (SOAPException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return null;
+    }
+
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/StripShellResponseHandler.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/StripShellResponseHandler.java
@@ -22,9 +22,12 @@ public class StripShellResponseHandler implements SOAPHandler<SOAPMessageContext
             if ("Create".equals(action.getLocalPart())) {
                 Iterator<?> childIter = getBodyChildren(context);
                 while(childIter.hasNext()) {
-                    SOAPElement el = (SOAPElement) childIter.next();
-                    if ("Shell".equals(el.getLocalName())) {
-                        childIter.remove();
+                    Object node = childIter.next();
+                    if (node instanceof SOAPElement) {
+                        SOAPElement el = (SOAPElement) node;
+                        if ("Shell".equals(el.getLocalName())) {
+                            childIter.remove();
+                        }
                     }
                 }
             }

--- a/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
+++ b/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
@@ -1,0 +1,281 @@
+package io.cloudsoft.winrm4j.client;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.apache.commons.codec.Charsets;
+import org.apache.http.client.config.AuthSchemes;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import org.xmlunit.matchers.CompareMatcher;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okio.Buffer;
+
+public class WinRmClientRecordedTest {
+    private static final Logger LOG = Logger.getLogger(WinRmClientRecordedTest.class.getName());
+    static final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+    static final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+    static {
+        documentBuilderFactory.setNamespaceAware(true);
+    }
+
+    @DataProvider
+    public Object[][] recordings() {
+        return new Object[][] {{"win7"}, {"win12"}};
+    }
+    
+    @Test(dataProvider="recordings", timeOut=30000)
+    public void testRecording(String recordingName) throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            // Use to fix the port for network capture
+            // server.start(5985);
+            URL serverUrl = server.url("/wsman").url();
+            RecordedSessionDispatcher dispatcher = new RecordedSessionDispatcher(recordingName, serverUrl.toString());
+            server.setDispatcher(dispatcher);
+            doRequest(serverUrl);
+            assertFalse(dispatcher.hasErrors(), "Dispatcher reported errors, see logs for details");
+        }
+    }
+
+    private void doRequest(URL url) {
+        WinRmClient.Builder builder = WinRmClient.builder(url, AuthSchemes.BASIC);
+
+        WinRmClient client = builder.build();
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        int code;
+
+        try {
+            code = client.command("echo myline", out, err);
+        } finally {
+            client.disconnect();
+        }
+
+        assertEquals(out.toString(), "myline\r\n");
+        assertEquals(err.toString(), "");
+        assertEquals(code, 0);
+    }
+
+    private static class RecordedSessionDispatcher extends Dispatcher {
+
+        String serverUrl;
+        String messageId;
+        Iterator<Item> requests;
+        String recordingName;
+        boolean hasErrors;
+
+        public RecordedSessionDispatcher(String recordingName, String serverUrl) {
+            this.serverUrl = serverUrl;
+            this.recordingName = recordingName;
+        }
+
+        public boolean hasErrors() {
+            return hasErrors;
+        }
+
+        @Override
+        public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+            try {
+                return doDispatch(request);
+            } catch (Throwable e) {
+                hasErrors = true;
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw (InterruptedException)e;
+                }
+                LOG.log(Level.SEVERE, "Processing request " + request + " failed", e);
+                return new MockResponse().setResponseCode(500);
+            }
+        }
+
+        private MockResponse doDispatch(RecordedRequest request) {
+            Document requestDoc = parseRequest(request);
+            if (messageId == null) {
+                initRecordedSession(requestDoc);
+            }
+
+            Item next = requests.next();
+
+            String contentType = request.getHeader("Content-Type");
+            assertEquals(contentType, "application/soap+xml; action=\"" + next.getAction() + "\"; charset=UTF-8");
+            CompareMatcher.isIdenticalTo(next.getRequest())
+                .throwComparisonFailure()
+                .ignoreWhitespace()
+                .matches(requestDoc.getFirstChild());
+
+            Buffer response = serializeResponse(next.getResponse());
+            LOG.fine("Sending response: \n" + response.toString());
+            return new MockResponse()
+                    .setHeader("Content-Type", "application/soap+xml;charset=UTF-8")
+                    .setBody(response);
+        }
+
+        private void initRecordedSession(Document requestDoc) {
+            messageId = getMessageId(requestDoc);
+            Document sessionDoc = parseSession(loadRecordedSession(recordingName, messageId, serverUrl));
+            requests = new RecordedSessionIterable(sessionDoc).iterator();
+        }
+
+    }
+
+    private static Buffer serializeResponse(Element response) {
+        Element envelope = response;
+        Transformer transformer;
+        try {
+            transformer = transformerFactory.newTransformer();
+            Buffer buffer = new Buffer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            transformer.transform(new DOMSource(envelope), new StreamResult(buffer.outputStream()));
+            return buffer;
+        } catch (TransformerException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Element getFirstElement(Node el) {
+        while (el != null && el.getNodeType() != Node.ELEMENT_NODE) {
+            el = el.getNextSibling();
+        }
+        return (Element)el;
+    }
+
+    private static String loadRecordedSession(String recordingName, String messageId, String serverUrl) {
+        String xml = loadResource(recordingName);
+        return xml.replace("${messageId}", messageId).replace("${serviceUrl}", serverUrl);
+    }
+
+    private static String loadResource(String recordingName) {
+        try {
+            URI recURI = WinRmClientRecordedTest.class.getClassLoader().getResource("recordings/" + recordingName + ".xml").toURI();
+            return new String(Files.readAllBytes(Paths.get(recURI)), Charsets.UTF_8);
+        } catch (IOException | URISyntaxException e) {
+            throw new IllegalStateException("Couldn't load recording", e);
+        }
+    }
+    private static Document parseSession(String loadRecordedSession) {
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            return builder.parse(new ByteArrayInputStream(loadRecordedSession.getBytes(Charsets.UTF_8)));
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Document parseRequest(RecordedRequest request) {
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            return builder.parse(request.getBody().inputStream());
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String getMessageId(Document doc) {
+        Element messageId = (Element) doc.getElementsByTagNameNS("http://schemas.xmlsoap.org/ws/2004/08/addressing", "MessageID").item(0);
+        return messageId.getTextContent();
+    }
+
+    private static class Item {
+        Element request;
+        Element response;
+        public Item(Element item) {
+            for (Element el = getFirstElement(item.getFirstChild()); el != null; el = getFirstElement(el.getNextSibling())) {
+                String localName = el.getTagName();
+                if (localName.equals("request")) {
+                    request = el;
+                } else if (localName.equals("response")) {
+                    response = el;
+                } else {
+                    throw new IllegalStateException("Unexpected element " + el);
+                }
+            }
+            if (request == null) {
+                throw new IllegalStateException("No request child found in " + item);
+            }
+            if (response == null) {
+                throw new IllegalStateException("No response child found in " + item);
+            }
+        }
+        public Element getRequest() {
+            return getFirstElement(request.getFirstChild());
+        };
+        public Element getResponse() {
+            return getFirstElement(response.getFirstChild());
+        };
+        public String getAction() {
+            return request.getAttribute("action");
+        }
+    }
+    private static class RecordedSessionIterable implements Iterable<Item> {
+        private NodeList nodes;
+        public RecordedSessionIterable(Document sessionDoc) {
+            this(sessionDoc.getDocumentElement().getChildNodes());
+        }
+
+        public RecordedSessionIterable(NodeList nodes) {
+            this.nodes = nodes;
+        }
+
+        @Override
+        public Iterator<Item> iterator() {
+            return new Iterator<Item>() {
+                private Element nextEl = getFirstElement(nodes.item(0));
+
+                @Override
+                public boolean hasNext() {
+                    return nextEl != null;
+                }
+
+                @Override
+                public Item next() {
+                    if (nextEl == null) {
+                        throw new NoSuchElementException();
+                    }
+                    Item ret = new Item(nextEl);
+                    nextEl = getFirstElement(nextEl.getNextSibling());
+                    return ret;
+                }
+
+                @Override
+                public void remove() {
+                    throw new IllegalStateException("Operation not supported");
+                }
+            };
+        }
+
+    }
+}

--- a/client/src/test/resources/recordings/win12.xml
+++ b/client/src/test/resources/recordings/win12.xml
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE recording [
+  <!ELEMENT recording (item*)>
+  <!ELEMENT item (request, response)>
+  <!ELEMENT request ANY>
+  <!ATTLIST request action CDATA #REQUIRED>
+  <!ELEMENT response ANY>
+]>
+<recording>
+  <item>
+    <request action="http://schemas.xmlsoap.org/ws/2004/09/transfer/Create">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:OptionSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WINRS_NOPROFILE">FALSE</ns2:Option>
+            <ns2:Option Name="WINRS_CODEPAGE">437</ns2:Option>
+          </ns2:OptionSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Shell
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:InputStreams>stdin</ns1:InputStreams>
+            <ns1:OutputStreams>stdout stderr</ns1:OutputStreams>
+          </ns1:Shell>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse</a:Action>
+          <a:MessageID>uuid:C008686A-510B-40D4-9ADA-36AB4545DDBE</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <x:ResourceCreated>
+            <a:Address>${serviceUrl}</a:Address>
+            <a:ReferenceParameters>
+              <w:ResourceURI>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+              <w:SelectorSet>
+                <w:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</w:Selector>
+              </w:SelectorSet>
+            </a:ReferenceParameters>
+          </x:ResourceCreated>
+          <rsp:Shell xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell">
+            <rsp:ShellId>AF161CE1-3D3F-46B7-A101-800DD70639A9</rsp:ShellId>
+            <rsp:ResourceUri>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</rsp:ResourceUri>
+            <rsp:Owner>WIN-9CCKIUF3APV\vagrant</rsp:Owner>
+            <rsp:ClientIP>172.28.128.1</rsp:ClientIP>
+            <rsp:IdleTimeOut>PT7200.000S</rsp:IdleTimeOut>
+            <rsp:InputStreams>stdin</rsp:InputStreams>
+            <rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
+            <rsp:ShellRunTime>P0DT0H0M0S</rsp:ShellRunTime>
+            <rsp:ShellInactivity>P0DT0H0M0S</rsp:ShellInactivity>
+          </rsp:Shell>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</ns2:Selector>
+          </ns2:SelectorSet>
+          <ns2:OptionSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WINRS_CONSOLEMODE_STDIN">TRUE</ns2:Option>
+            <ns2:Option Name="WINRS_SKIP_CMD_SHELL">FALSE</ns2:Option>
+          </ns2:OptionSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:CommandLine
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:Command>echo myline</ns1:Command>
+          </ns1:CommandLine>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandResponse</a:Action>
+          <a:MessageID>uuid:C70FD6D6-477E-4840-83FD-E927A7BA2C12</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:CommandResponse>
+            <rsp:CommandId>D6BF85B4-E0D0-4770-9330-F5474E967185</rsp:CommandId>
+          </rsp:CommandResponse>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Receive
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:DesiredStream ns1:CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185">stdout stderr</ns1:DesiredStream>
+          </ns1:Receive>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReceiveResponse</a:Action>
+          <a:MessageID>uuid:74A21DFC-D336-447D-8B4A-100973D77157</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:ReceiveResponse>
+            <rsp:Stream Name="stdout" CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185">bXlsaW5lDQo=</rsp:Stream>
+            <rsp:Stream Name="stdout" CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185" End="true" />
+            <rsp:Stream Name="stderr" CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185" End="true" />
+            <rsp:CommandState
+                CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185"
+                State="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done">
+              <rsp:ExitCode>0</rsp:ExitCode>
+            </rsp:CommandState>
+          </rsp:ReceiveResponse>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Signal
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              CommandId="D6BF85B4-E0D0-4770-9330-F5474E967185">
+            <ns1:Code>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate</ns1:Code>
+          </ns1:Signal>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SignalResponse</a:Action>
+          <a:MessageID>uuid:62D17943-1D1E-43DA-900A-8ED1059C26B5</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:SignalResponse />
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body />
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/DeleteResponse</a:Action>
+          <a:MessageID>uuid:1BFC3285-6F68-459E-B505-6EA3BF66B41D</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body></s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+</recording>

--- a/client/src/test/resources/recordings/win7.xml
+++ b/client/src/test/resources/recordings/win7.xml
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE recording [
+  <!ELEMENT recording (item*)>
+  <!ELEMENT item (request, response)>
+  <!ELEMENT request ANY>
+  <!ATTLIST request action CDATA #REQUIRED>
+  <!ELEMENT response ANY>
+]>
+<recording>
+  <item>
+    <request action="http://schemas.xmlsoap.org/ws/2004/09/transfer/Create">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/09/transfer/Create</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US"/>
+          <ns2:OptionSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WINRS_NOPROFILE">FALSE</ns2:Option>
+            <ns2:Option Name="WINRS_CODEPAGE">437</ns2:Option>
+          </ns2:OptionSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Shell
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:InputStreams>stdin</ns1:InputStreams>
+            <ns1:OutputStreams>stdout stderr</ns1:OutputStreams>
+          </ns1:Shell>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse</a:Action>
+          <a:MessageID>uuid:A186CD25-FA55-49B1-8EE4-D02D09B06344</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <x:ResourceCreated>
+            <a:Address>${serviceUrl}</a:Address>
+            <a:ReferenceParameters><w:ResourceURI>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</w:ResourceURI>
+              <w:SelectorSet>
+                <w:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</w:Selector>
+              </w:SelectorSet>
+            </a:ReferenceParameters>
+          </x:ResourceCreated>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</ns2:Selector>
+          </ns2:SelectorSet>
+          <ns2:OptionSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WINRS_CONSOLEMODE_STDIN">TRUE</ns2:Option>
+            <ns2:Option Name="WINRS_SKIP_CMD_SHELL">FALSE</ns2:Option>
+          </ns2:OptionSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:CommandLine
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:Command>echo myline</ns1:Command>
+          </ns1:CommandLine>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandResponse</a:Action>
+          <a:MessageID>uuid:86508F0F-DC53-4E11-8DCC-89FA0AA86740</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:CommandResponse>
+            <rsp:CommandId>0EC45416-057F-49E6-913F-5230FEF0F184</rsp:CommandId>
+          </rsp:CommandResponse>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Receive
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns1:DesiredStream ns1:CommandId="0EC45416-057F-49E6-913F-5230FEF0F184">stdout stderr</ns1:DesiredStream>
+          </ns1:Receive>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/ReceiveResponse</a:Action>
+          <a:MessageID>uuid:C49BBB1D-A40A-438B-8219-CFEBD97297DD</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:ReceiveResponse>
+            <rsp:Stream Name="stdout" CommandId="0EC45416-057F-49E6-913F-5230FEF0F184">bXlsaW5lDQo=</rsp:Stream>
+            <rsp:Stream Name="stdout" CommandId="0EC45416-057F-49E6-913F-5230FEF0F184" End="true" />
+            <rsp:Stream Name="stderr" CommandId="0EC45416-057F-49E6-913F-5230FEF0F184" End="true" />
+            <rsp:CommandState
+                CommandId="0EC45416-057F-49E6-913F-5230FEF0F184"
+                State="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done">
+              <rsp:ExitCode>0</rsp:ExitCode>
+            </rsp:CommandState>
+          </rsp:ReceiveResponse>
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body>
+          <ns1:Signal
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              CommandId="0EC45416-057F-49E6-913F-5230FEF0F184">
+            <ns1:Code>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate</ns1:Code>
+          </ns1:Signal>
+        </soap:Body>
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:rsp="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.microsoft.com/wbem/wsman/1/windows/shell/SignalResponse</a:Action>
+          <a:MessageID>uuid:F7C8A1C4-64FE-479D-B9AA-C1C90B22CB6F</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body>
+          <rsp:SignalResponse />
+        </s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+  <item>
+    <request action="http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete">
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header>
+          <Action xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete</Action>
+          <MessageID xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${messageId}</MessageID>
+          <To xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">${serviceUrl}</To>
+          <ReplyTo xmlns="http://schemas.xmlsoap.org/ws/2004/08/addressing">
+            <Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</Address>
+          </ReplyTo>
+          <ns2:ResourceURI
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >http://schemas.microsoft.com/wbem/wsman/1/windows/shell/cmd</ns2:ResourceURI>
+          <ns2:MaxEnvelopeSize
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >153600</ns2:MaxEnvelopeSize>
+          <ns2:OperationTimeout
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+            >PT60S</ns2:OperationTimeout>
+          <ns2:Locale
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer"
+              xml:lang="en-US" />
+          <ns2:SelectorSet
+              xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+              xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+              xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</ns2:Selector>
+          </ns2:SelectorSet>
+        </soap:Header>
+        <soap:Body />
+      </soap:Envelope>
+    </request>
+    <response>
+      <s:Envelope
+          xml:lang="en-US"
+          xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+          xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+          xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd">
+        <s:Header>
+          <a:Action>http://schemas.xmlsoap.org/ws/2004/09/transfer/DeleteResponse</a:Action>
+          <a:MessageID>uuid:B81168A5-086F-4973-9B55-BC18BD40E830</a:MessageID>
+          <a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To>
+          <a:RelatesTo>${messageId}</a:RelatesTo>
+        </s:Header>
+        <s:Body></s:Body>
+      </s:Envelope>
+    </response>
+  </item>
+</recording>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
     <testng.version>6.8.8</testng.version>
     <guava.version>17.0</guava.version>
     <cxf.version>3.1.4</cxf.version>
+    <mockwebserver.version>3.5.0</mockwebserver.version>
+    <xmlunit.version>2.3.0</xmlunit.version>
   </properties>
 
   <modules>

--- a/service/src/main/java/io/cloudsoft/winrm4j/service/WinRm.java
+++ b/service/src/main/java/io/cloudsoft/winrm4j/service/WinRm.java
@@ -13,7 +13,9 @@ import javax.xml.ws.RequestWrapper;
 
 import io.cloudsoft.winrm4j.service.shell.Receive;
 import io.cloudsoft.winrm4j.service.shell.ReceiveResponse;
+import io.cloudsoft.winrm4j.service.shell.Shell;
 import io.cloudsoft.winrm4j.service.shell.SignalResponse;
+import io.cloudsoft.winrm4j.service.transfer.ResourceCreated;
 import io.cloudsoft.winrm4j.service.wsman.Locale;
 import io.cloudsoft.winrm4j.service.wsman.OptionSetType;
 import io.cloudsoft.winrm4j.service.wsman.SelectorSetType;
@@ -118,9 +120,9 @@ public class WinRm {
     @Action(input = "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create", output = "http://schemas.xmlsoap.org/ws/2004/09/transfer/CreateResponse")
     @WebResult(name = "ResourceCreated", targetNamespace = "http://schemas.xmlsoap.org/ws/2004/09/transfer", partName = "ResourceCreated")
     @SOAPBinding(parameterStyle = SOAPBinding.ParameterStyle.BARE)
-    public io.cloudsoft.winrm4j.service.transfer.ResourceCreated create(
-        @WebParam(name = "Shell", mode = WebParam.Mode.INOUT, targetNamespace = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell")
-        javax.xml.ws.Holder<io.cloudsoft.winrm4j.service.shell.Shell> shell,
+    public ResourceCreated create(
+        @WebParam(name = "Shell", targetNamespace = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell")
+        Shell shell,
         @WebParam(name = "ResourceURI", targetNamespace = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", header = true)
         String resourceURI,
         @WebParam(name = "MaxEnvelopeSize", targetNamespace = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", header = true)


### PR DESCRIPTION
Makes the response identical between windows versions, making it possible to handle it with the same wsdl definition.

It's a hack to work around the JAX-WS limitations.

Fixes https://github.com/cloudsoft/winrm4j/issues/35.