### PR TITLE
WinRmClient cleanup

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/CliClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/CliClient.java
@@ -25,8 +25,6 @@ public class CliClient {
         int exitCode = 999;
         try (ShellCommand shell = client.createShell()){
             exitCode = shell.execute(cmd, new PrintWriter(new OutputStreamWriter(System.out)), new PrintWriter(new OutputStreamWriter(System.err)));
-        } finally {
-            client.disconnect();
         }
         System.exit(exitCode);
     }

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/CliClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/CliClient.java
@@ -6,12 +6,6 @@ import java.io.PrintWriter;
 public class CliClient {
 
     public static void main(String[] args) throws Exception{
-//        System.setProperty("com.sun.xml.ws.transport.http.client.HttpTransportPipe.dump", "true");
-//        System.setProperty("com.sun.xml.internal.ws.transport.http.client.HttpTransportPipe.dump", "true");
-//        System.setProperty("com.sun.xml.ws.transport.http.HttpAdapter.dump", "true");
-//        System.setProperty("com.sun.xml.internal.ws.transport.http.HttpAdapter.dump", "true");
-//        System.setProperty("com.sun.xml.internal.ws.transport.http.HttpAdapter.dumpTreshold", Integer.toString(Integer.MAX_VALUE));
-
         if (args.length != 4) {
             System.out.println("Usage: CliClient <endpoint> <username> <password> <command>");
         }
@@ -29,8 +23,8 @@ public class CliClient {
 //                .environment(env)
                 .build();
         int exitCode = 999;
-        try {
-            exitCode = client.command(cmd, new PrintWriter(new OutputStreamWriter(System.out)), new PrintWriter(new OutputStreamWriter(System.err)));
+        try (ShellCommand shell = client.createShell()){
+            exitCode = shell.execute(cmd, new PrintWriter(new OutputStreamWriter(System.out)), new PrintWriter(new OutputStreamWriter(System.err)));
         } finally {
             client.disconnect();
         }

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/RetryingProxyHandler.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/RetryingProxyHandler.java
@@ -1,0 +1,108 @@
+package io.cloudsoft.winrm4j.client;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.ws.Action;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.WebServiceException;
+import javax.xml.ws.soap.SOAPFaultException;
+
+import org.apache.cxf.ws.addressing.AddressingProperties;
+import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RetryingProxyHandler implements InvocationHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(RetryingProxyHandler.class);
+
+    private final WinRm winrm;
+    private int retriesForConnectionFailures;
+
+
+    public RetryingProxyHandler(WinRm winrm, int retriesForConnectionFailures) {
+        this.winrm = winrm;
+        this.retriesForConnectionFailures = retriesForConnectionFailures;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        //TODO use different instances of service http://cxf.apache.org/docs/developing-a-consumer.html#DevelopingaConsumer-SettingConnectionPropertieswithContexts
+        setActionToContext(method);
+
+        // Don't retry the "command" - could lead to unexpected side effects of having the script run multiple times.
+        if (method.getName().equals("command")) {
+            return method.invoke(winrm, args);
+        } else {
+            return invokeWithRetry(method, args);
+        }
+    }
+
+    public Object invokeWithRetry(Method method, Object[] args)
+            throws IllegalAccessException, InvocationTargetException {
+        List<Throwable> exceptions = new ArrayList<>();
+
+        for (int i = 0; i < retriesForConnectionFailures + 1; i++) {
+            try {
+                return method.invoke(winrm, args);
+            } catch (InvocationTargetException targetException) {
+                Throwable e = targetException.getTargetException();
+                if (e instanceof SOAPFaultException) {
+                    throw (SOAPFaultException)e;
+                } else if (e instanceof WebServiceException) {
+                    WebServiceException wsException = (WebServiceException) e;
+                    if (!(wsException.getCause() instanceof IOException)) {
+                        throw new RuntimeException("Exception occurred while making winrm call", wsException);
+                    }
+                    LOG.debug("Ignoring exception and retrying (attempt " + (i + 1) + " of " + (retriesForConnectionFailures + 1) + ") {}", wsException);
+                    try {
+                        Thread.sleep(5 * 1000);
+                    } catch (InterruptedException interruptedException) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Exception occured while making winrm call", e.initCause(wsException));
+                    }
+                    exceptions.add(wsException);
+                } else {
+                    throw new IllegalStateException("Failure when calling " + method + args, e);
+                }
+            }
+        }
+        throw new RuntimeException("failed task " + method.getName(), exceptions.get(0));
+    }
+
+    // TODO fix CXF to not set a wrong action https://issues.apache.org/jira/browse/CXF-4647
+    private void setActionToContext(Method method) {
+        Action action = method.getAnnotation(Action.class);
+        if (action != null && action.input() != null) {
+            AttributedURIType attrUri = new AttributedURIType();
+            attrUri.setValue(action.input());
+            AddressingProperties addrProps = getAddressingProperties((BindingProvider)winrm);
+            addrProps.setAction(attrUri);
+        }
+    }
+
+    private AddressingProperties getAddressingProperties(BindingProvider bp) {
+        String ADDR_CONTEXT = "javax.xml.ws.addressing.context";
+        Map<String, Object> reqContext = bp.getRequestContext();
+        if (reqContext==null) {
+            throw new NullPointerException("Unable to load request context; delegate load failed");
+        }
+
+        AddressingProperties addrProps = ((AddressingProperties)reqContext.get(ADDR_CONTEXT));
+        if (addrProps==null) {
+            throw new NullPointerException("Unable to load request context "+ADDR_CONTEXT+"; are the addressing classes installed (you may need <feature>cxf-ws-addr</feature> if running in osgi)");
+        }
+        return addrProps;
+    }
+
+    @Deprecated
+    public void setRetriesForConnectionFailures(int retries) {
+        this.retriesForConnectionFailures = retries;
+    }
+
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
@@ -148,6 +148,8 @@ public class ShellCommand implements AutoCloseable {
         }
     }
 
+    /** @deprecated since 0.6.0. Implementation detail, access will be removed in future versions */
+    @Deprecated
     public int getNumberOfReceiveCalls() {
         return numberOfReceiveCalls;
     }

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
@@ -1,0 +1,241 @@
+package io.cloudsoft.winrm4j.client;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.soap.SOAPFaultException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
+
+import io.cloudsoft.winrm4j.client.WinRmClient.CallableFunction;
+import io.cloudsoft.winrm4j.client.shell.CommandLine;
+import io.cloudsoft.winrm4j.client.shell.CommandStateType;
+import io.cloudsoft.winrm4j.client.shell.DesiredStreamType;
+import io.cloudsoft.winrm4j.client.shell.Receive;
+import io.cloudsoft.winrm4j.client.shell.ReceiveResponse;
+import io.cloudsoft.winrm4j.client.shell.StreamType;
+import io.cloudsoft.winrm4j.client.wsman.CommandResponse;
+import io.cloudsoft.winrm4j.client.wsman.DeleteResponse;
+import io.cloudsoft.winrm4j.client.wsman.Locale;
+import io.cloudsoft.winrm4j.client.wsman.OptionSetType;
+import io.cloudsoft.winrm4j.client.wsman.OptionType;
+import io.cloudsoft.winrm4j.client.wsman.SelectorSetType;
+import io.cloudsoft.winrm4j.client.wsman.SelectorType;
+import io.cloudsoft.winrm4j.client.wsman.Signal;
+import io.cloudsoft.winrm4j.client.wsman.SignalResponse;
+
+public class ShellCommand implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(ShellCommand.class.getName());
+
+    private static final String COMMAND_STATE_DONE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done";
+
+    /**
+     * If no output is available before the wsman:OperationTimeout expires, the server MUST return a WSManFault with the Code attribute equal to "2150858793"
+     * https://msdn.microsoft.com/en-us/library/cc251676.aspx
+     */
+    private static final String WSMAN_FAULT_CODE_OPERATION_TIMEOUT_EXPIRED = "2150858793";
+
+    /**
+     * Example response:
+     *   [truncated]The request for the Windows Remote Shell with ShellId xxxx-yyyy-ccc... failed because the shell was not found on the server.
+     *   Possible causes are: the specified ShellId is incorrect or the shell no longer exi
+     */
+    private static final String WSMAN_FAULT_CODE_SHELL_WAS_NOT_FOUND = "2150858843";
+
+    private WinRm winrm;
+    private SelectorSetType shellSelector;
+
+    private String operationTimeout;
+    private final Locale locale;
+    private final Integer retriesForConnectionFailures;
+
+    private int numberOfReceiveCalls;
+
+    public ShellCommand(WinRm winrm, String shellId, String operationTimeout, Locale locale, Integer retriesForConnectionFailures) {
+        this.winrm = winrm;
+        this.shellSelector = createShellSelector(shellId);
+        this.operationTimeout = operationTimeout;
+        this.locale = locale;
+        this.retriesForConnectionFailures = retriesForConnectionFailures;
+    }
+
+    private SelectorSetType createShellSelector(String shellId) {
+        SelectorSetType shellSelector = new SelectorSetType();
+        SelectorType sel = new SelectorType();
+        sel.setName("ShellId");
+        sel.getContent().add(shellId);
+        shellSelector.getSelector().add(sel);
+        return shellSelector;
+    }
+
+    public int execute(String cmd, Writer out, Writer err) {
+        WinRmClient.checkNotNull(cmd, "command");
+
+        final CommandLine cmdLine = new CommandLine();
+        cmdLine.setCommand(cmd);
+        final OptionSetType optSetCmd = new OptionSetType();
+        OptionType optConsolemodeStdin = new OptionType();
+        optConsolemodeStdin.setName("WINRS_CONSOLEMODE_STDIN");
+        optConsolemodeStdin.setValue("TRUE");
+        optSetCmd.getOption().add(optConsolemodeStdin);
+        OptionType optSkipCmdShell = new OptionType();
+        optSkipCmdShell.setName("WINRS_SKIP_CMD_SHELL");
+        optSkipCmdShell.setValue("FALSE");
+        optSetCmd.getOption().add(optSkipCmdShell);
+
+        numberOfReceiveCalls = 0;
+        //TODO use different instances of service http://cxf.apache.org/docs/developing-a-consumer.html#DevelopingaConsumer-SettingConnectionPropertieswithContexts
+        WinRmClient.setActionToContext((BindingProvider) winrm, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command");
+        CommandResponse cmdResponse = winrm.command(cmdLine, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector, optSetCmd);
+
+        String commandId = cmdResponse.getCommandId();
+
+        try {
+            return receiveCommand(commandId, out, err);
+        } finally {
+            try {
+                releaseCommand(commandId);
+            } catch (SOAPFaultException soapFault) {
+                assertFaultCode(soapFault, WSMAN_FAULT_CODE_SHELL_WAS_NOT_FOUND);
+            }
+        }
+    }
+
+    private int receiveCommand(String commandId, Writer out, Writer err) {
+        while(true) {
+            final Receive receive = new Receive();
+            DesiredStreamType stream = new DesiredStreamType();
+            stream.setCommandId(commandId);
+            stream.setValue("stdout stderr");
+            receive.setDesiredStream(stream);
+
+
+            try {
+                numberOfReceiveCalls++;
+                ReceiveResponse receiveResponse = WinRmClient.winrmCallRetryConnFailure(new WinRmClient.CallableFunction<ReceiveResponse>() {
+                    @Override
+                    public ReceiveResponse call() {
+                        //TODO use different instances of service http://cxf.apache.org/docs/developing-a-consumer.html#DevelopingaConsumer-SettingConnectionPropertieswithContexts
+                        WinRmClient.setActionToContext((BindingProvider) winrm, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive");
+                        return winrm.receive(receive, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector);
+                    }
+                }, retriesForConnectionFailures);
+                getStreams(receiveResponse, out, err);
+
+                CommandStateType state = receiveResponse.getCommandState();
+                if (COMMAND_STATE_DONE.equals(state.getState())) {
+                    return state.getExitCode().intValue();
+                } else {
+                    LOG.debug("{} is not done. Response it received: {}", this, receiveResponse);
+                }
+            } catch (SOAPFaultException soapFault) {
+                /**
+                 * If such Exception which has a code 2150858793 the client is expected to again trigger immediately a receive request.
+                 * https://msdn.microsoft.com/en-us/library/cc251676.aspx
+                 */
+                assertFaultCode(soapFault, WSMAN_FAULT_CODE_OPERATION_TIMEOUT_EXPIRED);
+            }
+        }
+    }
+
+    private void assertFaultCode(SOAPFaultException soapFault, String code) {
+        try {
+            NodeList faultDetails = soapFault.getFault().getDetail().getChildNodes();
+            for (int i = 0; i < faultDetails.getLength(); i++) {
+                if (faultDetails.item(i).getLocalName().equals("WSManFault")) {
+                    if (faultDetails.item(i).getAttributes().getNamedItem("Code").getNodeValue().equals(code)) {
+                        LOG.trace("winrm client {} received error 500 response with code {}, response {}", this, code, soapFault);
+                        return;
+                    } else {
+                        throw soapFault;
+                    }
+                }
+            }
+            throw soapFault;
+        } catch (NullPointerException e) {
+            LOG.debug("Error reading Fault Code {}", soapFault.getFault());
+            throw soapFault;
+        }
+    }
+
+    public int getNumberOfReceiveCalls() {
+        return numberOfReceiveCalls;
+    }
+
+    private void getStreams(ReceiveResponse receiveResponse, Writer out, Writer err) {
+        List<StreamType> streams = receiveResponse.getStream();
+        for (StreamType s : streams) {
+            byte[] value = s.getValue();
+            if (value == null) continue;
+            if (out != null && "stdout".equals(s.getName())) {
+                try {
+                    //TODO use passed locale?
+                    if (value.length > 0) {
+                        out.write(new String(value));
+                    }
+                    if (Boolean.TRUE.equals(s.isEnd())) {
+                        out.close();
+                    }
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+            if (err != null && "stderr".equals(s.getName())) {
+                try {
+                    //TODO use passed locale?
+                    if (value.length > 0) {
+                        err.write(new String(value));
+                    }
+                    if (Boolean.TRUE.equals(s.isEnd())) {
+                        err.close();
+                    }
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+        try {
+            out.close();
+            err.close();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void releaseCommand(String commandId) {
+        final Signal signal = new Signal();
+        signal.setCommandId(commandId);
+        signal.setCode("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate");
+
+        WinRmClient.winrmCallRetryConnFailure(new CallableFunction<SignalResponse>() {
+            @Override
+            public SignalResponse call() {
+                //TODO use different instances of service http://cxf.apache.org/docs/developing-a-consumer.html#DevelopingaConsumer-SettingConnectionPropertieswithContexts
+                WinRmClient.setActionToContext((BindingProvider) winrm, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal");
+                return winrm.signal(signal, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector);
+            }
+        }, retriesForConnectionFailures);
+
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            WinRmClient.winrmCallRetryConnFailure(new CallableFunction<DeleteResponse>() {
+                @Override
+                public DeleteResponse call() {
+                    //TODO use different instances of service http://cxf.apache.org/docs/developing-a-consumer.html#DevelopingaConsumer-SettingConnectionPropertieswithContexts
+                    WinRmClient.setActionToContext((BindingProvider) winrm, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Delete");
+                    return winrm.delete(null, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector);
+                }
+            }, retriesForConnectionFailures);
+        } catch (SOAPFaultException soapFault) {
+            assertFaultCode(soapFault, WSMAN_FAULT_CODE_SHELL_WAS_NOT_FOUND);
+        }
+    }
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -2,7 +2,6 @@ package io.cloudsoft.winrm4j.client;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -20,24 +19,16 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.xml.ws.BindingProvider;
-import javax.xml.ws.WebServiceFeature;
 import javax.xml.ws.handler.Handler;
 import javax.xml.ws.soap.SOAPFaultException;
-import javax.xml.ws.spi.Provider;
-import javax.xml.ws.spi.ServiceDelegate;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.cxf.Bus;
 import org.apache.cxf.Bus.BusState;
-import org.apache.cxf.BusFactory;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.feature.Feature;
 import org.apache.cxf.frontend.ClientProxy;
-import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
-import org.apache.cxf.jaxws.spi.ProviderImpl;
 import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
@@ -45,7 +36,6 @@ import org.apache.cxf.ws.addressing.AddressingProperties;
 import org.apache.cxf.ws.addressing.AttributedURIType;
 import org.apache.cxf.ws.addressing.JAXWSAConstants;
 import org.apache.cxf.ws.addressing.VersionTransformer;
-import org.apache.cxf.ws.addressing.WSAddressingFeature;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
@@ -324,155 +314,12 @@ public class WinRmClient {
                 cleanupContext = true;
             }
 
-            WinRm service = newInstance(context.getBus());
+            WinRm service = WinRmFactory.newInstance(context.getBus());
             initializeClientAndService(service);
             winrm = service;
         }
     }
 
-    public static WinRm newInstance(Bus bus) {
-        Bus prevBus = BusFactory.getAndSetThreadDefaultBus(bus);
-        try {
-            // The default thread bus is set on the ClientImpl and used for further requests
-            return createService(bus);
-        } finally {
-            if (BusFactory.getThreadDefaultBus(false) != prevBus) {
-                BusFactory.setThreadDefaultBus(prevBus);
-            }
-        }
-    }
-
-    private static WinRm createService(Bus bus) {
-        RuntimeException lastException = null;
-        
-        try {
-            return doCreateServiceWithBean(bus);
-        } catch (RuntimeException e) {
-            LOG.warn("Error creating WinRm service with mbean strategy (trying other strategies): "+e, e);
-            lastException = e;
-        }
-        
-        /*
-         * It's tedious getting the right Provider esp in OSGi.
-         * 
-         * We've tried a bunch of strategies, with the most promising tried here,
-         * and detailed notes below.
-         */
-        
-        try {
-            return doCreateServiceWithReflectivelySetDelegate();
-        } catch (RuntimeException e) {
-            LOG.warn("Error creating WinRm service with reflective delegate (trying other strategies): "+e, e);
-            lastException = e;
-        }
-        
-        try {
-            return doCreateServiceNormal();
-        } catch (RuntimeException e) {
-            LOG.warn("Error creating WinRm service with many strategies (giving up): "+e, e);
-            lastException = e;
-        }
-        
-        throw lastException;
-
-        // works, but addressing context might be null
-//        doCreateServiceWithReflectivelySetDelegate();
-        
-        // fails with NPE setting up feature (Bus is null)
-        // but it works if you install into karaf:  <feature>cxf-ws-addr</feature>
-//        doCreateServiceWithBean();
-        // also fails with NPE without that feature installed; untested with it
-//        doCreateServiceInSpecialClassLoader( ProviderImpl.class.getClassLoader() );
-//        doCreateServiceInSpecialClassLoader( JaxWsProxyFactoryBean.class.getClassLoader() );
-        
-        // fails in OSGi with CNF error when FactoryFinder tries to load the CXF impl 
-//        doCreateServiceWithSystemPropertySet();
-        
-        // fails in OSGi, with original error:
-        // com.sun.xml.internal.ws.client.sei.SEIStub cannot be cast to org.apache.cxf.frontend.ClientProxy
-        // at: ClientProxy.getClient(...);
-//        doCreateServiceNormal();
-//        doCreateServiceInSpecialClassLoader( WinRmClient.class.getClassLoader() );
-    }
-    
-    // normal approach
-    private static WinRm doCreateServiceNormal() {
-        WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
-        return doCreateService_2_GetClient(service);
-    }
-
-    //  sys prop approach
-    @SuppressWarnings("unused")
-    private void doCreateServiceWithSystemPropertySet() {
-        System.setProperty("javax.xml.ws.spi.Provider", ProviderImpl.class.getName());
-        doCreateServiceNormal();
-    }
-    
-    // force delegate
-    // based on http://stackoverflow.com/a/31892206/109079
-    private static WinRm doCreateServiceWithReflectivelySetDelegate() {
-        WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
-
-        try {
-            Field delegateField = javax.xml.ws.Service.class.getDeclaredField("delegate"); //ALLOW CXF SPECIFIC SERVICE DELEGATE ONLY!
-            delegateField.setAccessible(true);
-            ServiceDelegate previousDelegate = (ServiceDelegate) delegateField.get(service);
-            if (!previousDelegate.getClass().getName().contains("cxf")) {
-                ServiceDelegate serviceDelegate = ((Provider) Class.forName("org.apache.cxf.jaxws.spi.ProviderImpl").newInstance())
-                        .createServiceDelegate(WinRmService.WSDL_LOCATION, WinRmService.SERVICE, service.getClass());
-                delegateField.set(service, serviceDelegate);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Error reflectively setting CXF WS service delegate", e);
-        }
-        return doCreateService_2_GetClient(service);
-    }
-    
-    // approach using JaxWsProxyFactoryBean
-    
-    private static WinRm doCreateServiceWithBean(Bus bus) {
-        JaxWsProxyFactoryBean factory = new JaxWsProxyFactoryBean();
-        factory.getClientFactoryBean().getServiceFactory().setWsdlURL(WinRmService.WSDL_LOCATION);
-        factory.setServiceName(WinRmService.SERVICE);
-        factory.setEndpointName(WinRmService.WinRmPort);
-        factory.setFeatures(Arrays.asList((Feature)newMemberSubmissionAddressingFeature()));
-        factory.setBus(bus);
-        return factory.create(WinRm.class);
-    }
-
-    // approach using CCL
-
-    @SuppressWarnings("unused")
-    private static WinRm doCreateServiceInSpecialClassLoader(ClassLoader cl) {
-        
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        
-        Client client;
-        try {
-            // use CXF classloader in order to avoid errors in osgi
-            // as described at http://stackoverflow.com/questions/24289151/eclipse-rcp-and-apache-cxf
-            // do this for as short a time as possible to prevent other potential issues
-            Thread.currentThread().setContextClassLoader(cl);
-            
-            WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
-            return doCreateService_2_GetClient(service);
-            
-        } finally {
-            Thread.currentThread().setContextClassLoader(classLoader);
-        }
-    }
-        
-    private static WinRmService doCreateService_1_CreateMinimalServiceInstance() {
-        return new WinRmService();
-    }
-
-    private static WinRm doCreateService_2_GetClient(WinRmService service) {
-        return service.getWinRmPort(
-                // * Adds WS-Addressing headers and uses the submission spec namespace
-                //   http://schemas.xmlsoap.org/ws/2004/08/addressing
-                newMemberSubmissionAddressingFeature());
-    }
-    
     private void initializeClientAndService(WinRm winrm) {
         Client client = ClientProxy.getClient(winrm);
         ServiceInfo si = client.getEndpoint().getEndpointInfo().getService();
@@ -613,30 +460,6 @@ public class WinRmClient {
             }
         }
         throw new IllegalStateException("Shell ID not fount in " + resourceCreated);
-    }
-
-    // TODO
-    private static WebServiceFeature newMemberSubmissionAddressingFeature() {
-        /*
-         * Requires the following dependency so the feature is visible to maven.
-         * But is it included in the IBM dist?
-<dependency>
-    <groupId>com.sun.xml.ws</groupId>
-    <artifactId>jaxws-rt</artifactId>
-    <version>2.2.10</version>
-</dependency>
-         */
-        try {
-            // com.ibm.websphere.wsaddressing.jaxws21.SubmissionAddressingFeature for IBM java (available only in WebSphere?)
-
-            WSAddressingFeature webServiceFeature = new WSAddressingFeature();
-//            webServiceFeature.setResponses(WSAddressingFeature.AddressingResponses.ANONYMOUS);
-            webServiceFeature.setAddressingRequired(true);
-
-            return webServiceFeature;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public void disconnect() {

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -195,12 +195,14 @@ public class WinRmClient {
         return initInstanceShell().execute(cmd, out, err);
     }
 
-    /**
-     * @deprecated since 0.6.0. Exposed for tests only. Will be removed.
-     */
+    /** @deprecated since 0.6.0. Implementation detail, access will be removed in future versions. */
     @Deprecated
     public int getNumberOfReceiveCalls() {
-        return shellCommand.getNumberOfReceiveCalls();
+        if (shellCommand == null) {
+            return 0;
+        } else {
+            return shellCommand.getNumberOfReceiveCalls();
+        }
     }
 
     private static void initializeClientAndService(WinRm winrm, WinRmClientBuilder builder) {

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -1,0 +1,162 @@
+package io.cloudsoft.winrm4j.client;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import javax.net.ssl.HostnameVerifier;
+
+import org.apache.http.client.config.AuthSchemes;
+
+import io.cloudsoft.winrm4j.client.wsman.Locale;
+
+public class WinRmClientBuilder {
+    private static final java.util.Locale DEFAULT_LOCALE = java.util.Locale.US;
+    private static final Long DEFAULT_OPERATION_TIMEOUT = 60l * 1000l;
+    private static final int DEFAULT_RETRIES_FOR_CONNECTION_FAILURES = 1;
+
+    protected WinRmClientContext context;
+    protected final URL endpoint;
+    protected String authenticationScheme;
+    protected String domain;
+    protected String username;
+    protected String password;
+    protected String workingDirectory;
+    protected Locale locale;
+    protected long operationTimeout;
+    protected Long receiveTimeout;
+    protected int retriesForConnectionFailures;
+    protected Map<String, String> environment;
+
+    protected boolean disableCertificateChecks;
+    protected HostnameVerifier hostnameVerifier;
+
+    WinRmClientBuilder(String endpoint) {
+        this(toUrlUnchecked(WinRmClient.checkNotNull(endpoint, "endpoint")));
+    }
+
+    WinRmClientBuilder(URL endpoint) {
+        this.endpoint = WinRmClient.checkNotNull(endpoint, "endpoint");
+        authenticationScheme(AuthSchemes.NTLM);
+        locale(DEFAULT_LOCALE);
+        operationTimeout(DEFAULT_OPERATION_TIMEOUT);
+        retriesForConnectionFailures(DEFAULT_RETRIES_FOR_CONNECTION_FAILURES);
+    }
+
+    public WinRmClientBuilder authenticationScheme(String authenticationScheme) {
+        this.authenticationScheme = WinRmClient.checkNotNull(authenticationScheme, "authenticationScheme");
+        return this;
+    }
+
+    public WinRmClientBuilder credentials(String username, String password) {
+        return credentials(null, username, password);
+    }
+
+    /**
+     * Credentials to use for authentication
+     */
+    public WinRmClientBuilder credentials(String domain, String username, String password) {
+        this.domain = domain;
+        this.username = WinRmClient.checkNotNull(username, "username");
+        this.password = WinRmClient.checkNotNull(password, "password");
+        return this;
+    }
+
+    /**
+     * @param locale The locale to run the process in
+     */
+    public WinRmClientBuilder locale(java.util.Locale locale) {
+        Locale l = new Locale();
+        l.setLang(WinRmClient.checkNotNull(locale, "locale").toLanguageTag());
+        this.locale = l;
+        return this;
+    }
+
+    /**
+     * If operations cannot be completed in a specified time,
+     * the service returns a fault so that a client can comply with its obligations.
+     * http://www.dmtf.org/sites/default/files/standards/documents/DSP0226_1.2.0.pdf
+     *
+     * @param operationTimeout in milliseconds
+     *                         default value {@link WinRmClient.Builder#DEFAULT_OPERATION_TIMEOUT}
+     */
+    public WinRmClientBuilder operationTimeout(long operationTimeout) {
+        this.operationTimeout = WinRmClient.checkNotNull(operationTimeout, "operationTimeout");
+        return this;
+    }
+
+    /**
+     * @param retriesConnectionFailures How many times to retry the command before giving up in case of failure (exception).
+     *        Default is 16.
+     */
+    public WinRmClientBuilder retriesForConnectionFailures(int retriesConnectionFailures) {
+        if (retriesConnectionFailures < 1) {
+            throw new IllegalArgumentException("retriesConnectionFailure should be one or more");
+        }
+        this.retriesForConnectionFailures = retriesConnectionFailures;
+        return this;
+    }
+
+
+    /**
+     * @param disableCertificateChecks Skip trusted certificate and domain (CN) checks.
+     *        Used when working with self-signed certificates. Use {@link #hostnameVerifier(HostnameVerifier)}
+     *        for a more precise white-listing of server certificates.
+     */
+    public WinRmClientBuilder disableCertificateChecks(boolean disableCertificateChecks) {
+        this.disableCertificateChecks = disableCertificateChecks;
+        return this;
+    }
+
+    /**
+     * @param workingDirectory the working directory of the process
+     */
+    public WinRmClientBuilder workingDirectory(String workingDirectory) {
+        this.workingDirectory = WinRmClient.checkNotNull(workingDirectory, "workingDirectory");
+        return this;
+    }
+
+    /**
+     * @param environment variables to pass to the command
+     */
+    public WinRmClientBuilder environment(Map<String, String> environment) {
+        this.environment = WinRmClient.checkNotNull(environment, "environment");
+        return this;
+    }
+
+    /**
+     * @param hostnameVerifier override the default HostnameVerifier allowing
+     *        users to add custom validation logic. Used when the default rules for URL
+     *        hostname verification fail. Use {@link #disableCertificateChecks(boolean)} to
+     *        disable certificate checks for all host names.
+     */
+    public WinRmClientBuilder hostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+        return this;
+    }
+
+    /**
+     * @param context is a shared {@link WinRmClientContext} object which allows connection
+     *        reuse across {@link WinRmClient} invocations. If not set one will be created
+     *        for each {@link WinRmClient} instance.
+     */
+    public WinRmClientBuilder context(WinRmClientContext context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Create a WinRmClient
+     */
+    public WinRmClient build() {
+        return new WinRmClient(this);
+    }
+
+    protected static URL toUrlUnchecked(String endpoint) {
+        try {
+            return new URL(endpoint);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientContext.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientContext.java
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package io.cloudsoft.winrm4j.client;
 
 import org.apache.cxf.Bus;

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmFactory.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmFactory.java
@@ -1,0 +1,189 @@
+package io.cloudsoft.winrm4j.client;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import javax.xml.ws.WebServiceFeature;
+import javax.xml.ws.spi.Provider;
+import javax.xml.ws.spi.ServiceDelegate;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.feature.Feature;
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.jaxws.spi.ProviderImpl;
+import org.apache.cxf.ws.addressing.WSAddressingFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WinRmFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(WinRmClient.class.getName());
+
+    public static WinRm newInstance(Bus bus) {
+        Bus prevBus = BusFactory.getAndSetThreadDefaultBus(bus);
+        try {
+            // The default thread bus is set on the ClientImpl and used for further requests
+            return createService(bus);
+        } finally {
+            if (BusFactory.getThreadDefaultBus(false) != prevBus) {
+                BusFactory.setThreadDefaultBus(prevBus);
+            }
+        }
+    }
+
+    private static WinRm createService(Bus bus) {
+        RuntimeException lastException = null;
+        
+        try {
+            return doCreateServiceWithBean(bus);
+        } catch (RuntimeException e) {
+            LOG.warn("Error creating WinRm service with mbean strategy (trying other strategies): "+e, e);
+            lastException = e;
+        }
+        
+        /*
+         * It's tedious getting the right Provider esp in OSGi.
+         * 
+         * We've tried a bunch of strategies, with the most promising tried here,
+         * and detailed notes below.
+         */
+        
+        try {
+            return doCreateServiceWithReflectivelySetDelegate();
+        } catch (RuntimeException e) {
+            LOG.warn("Error creating WinRm service with reflective delegate (trying other strategies): "+e, e);
+            lastException = e;
+        }
+        
+        try {
+            return doCreateServiceNormal();
+        } catch (RuntimeException e) {
+            LOG.warn("Error creating WinRm service with many strategies (giving up): "+e, e);
+            lastException = e;
+        }
+        
+        throw lastException;
+
+        // works, but addressing context might be null
+//        doCreateServiceWithReflectivelySetDelegate();
+        
+        // fails with NPE setting up feature (Bus is null)
+        // but it works if you install into karaf:  <feature>cxf-ws-addr</feature>
+//        doCreateServiceWithBean();
+        // also fails with NPE without that feature installed; untested with it
+//        doCreateServiceInSpecialClassLoader( ProviderImpl.class.getClassLoader() );
+//        doCreateServiceInSpecialClassLoader( JaxWsProxyFactoryBean.class.getClassLoader() );
+        
+        // fails in OSGi with CNF error when FactoryFinder tries to load the CXF impl 
+//        doCreateServiceWithSystemPropertySet();
+        
+        // fails in OSGi, with original error:
+        // com.sun.xml.internal.ws.client.sei.SEIStub cannot be cast to org.apache.cxf.frontend.ClientProxy
+        // at: ClientProxy.getClient(...);
+//        doCreateServiceNormal();
+//        doCreateServiceInSpecialClassLoader( WinRmClient.class.getClassLoader() );
+    }
+    
+    // normal approach
+    private static WinRm doCreateServiceNormal() {
+        WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
+        return doCreateService_2_GetClient(service);
+    }
+
+    //  sys prop approach
+    @SuppressWarnings("unused")
+    private void doCreateServiceWithSystemPropertySet() {
+        System.setProperty("javax.xml.ws.spi.Provider", ProviderImpl.class.getName());
+        doCreateServiceNormal();
+    }
+    
+    // force delegate
+    // based on http://stackoverflow.com/a/31892206/109079
+    private static WinRm doCreateServiceWithReflectivelySetDelegate() {
+        WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
+
+        try {
+            Field delegateField = javax.xml.ws.Service.class.getDeclaredField("delegate"); //ALLOW CXF SPECIFIC SERVICE DELEGATE ONLY!
+            delegateField.setAccessible(true);
+            ServiceDelegate previousDelegate = (ServiceDelegate) delegateField.get(service);
+            if (!previousDelegate.getClass().getName().contains("cxf")) {
+                ServiceDelegate serviceDelegate = ((Provider) Class.forName("org.apache.cxf.jaxws.spi.ProviderImpl").newInstance())
+                        .createServiceDelegate(WinRmService.WSDL_LOCATION, WinRmService.SERVICE, service.getClass());
+                delegateField.set(service, serviceDelegate);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflectively setting CXF WS service delegate", e);
+        }
+        return doCreateService_2_GetClient(service);
+    }
+    
+    // approach using JaxWsProxyFactoryBean
+    
+    private static WinRm doCreateServiceWithBean(Bus bus) {
+        JaxWsProxyFactoryBean factory = new JaxWsProxyFactoryBean();
+        factory.getClientFactoryBean().getServiceFactory().setWsdlURL(WinRmService.WSDL_LOCATION);
+        factory.setServiceName(WinRmService.SERVICE);
+        factory.setEndpointName(WinRmService.WinRmPort);
+        factory.setFeatures(Arrays.asList((Feature)newMemberSubmissionAddressingFeature()));
+        factory.setBus(bus);
+        return factory.create(WinRm.class);
+    }
+
+    // approach using CCL
+
+    @SuppressWarnings("unused")
+    private static WinRm doCreateServiceInSpecialClassLoader(ClassLoader cl) {
+        
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        
+        Client client;
+        try {
+            // use CXF classloader in order to avoid errors in osgi
+            // as described at http://stackoverflow.com/questions/24289151/eclipse-rcp-and-apache-cxf
+            // do this for as short a time as possible to prevent other potential issues
+            Thread.currentThread().setContextClassLoader(cl);
+            
+            WinRmService service = doCreateService_1_CreateMinimalServiceInstance();
+            return doCreateService_2_GetClient(service);
+            
+        } finally {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        }
+    }
+        
+    private static WinRmService doCreateService_1_CreateMinimalServiceInstance() {
+        return new WinRmService();
+    }
+
+    private static WinRm doCreateService_2_GetClient(WinRmService service) {
+        return service.getWinRmPort(
+                // * Adds WS-Addressing headers and uses the submission spec namespace
+                //   http://schemas.xmlsoap.org/ws/2004/08/addressing
+                newMemberSubmissionAddressingFeature());
+    }
+    
+    private static WebServiceFeature newMemberSubmissionAddressingFeature() {
+        /*
+         * Requires the following dependency so the feature is visible to maven.
+         * But is it included in the IBM dist?
+<dependency>
+    <groupId>com.sun.xml.ws</groupId>
+    <artifactId>jaxws-rt</artifactId>
+    <version>2.2.10</version>
+</dependency>
+         */
+        try {
+            // com.ibm.websphere.wsaddressing.jaxws21.SubmissionAddressingFeature for IBM java (available only in WebSphere?)
+
+            WSAddressingFeature webServiceFeature = new WSAddressingFeature();
+//            webServiceFeature.setResponses(WSAddressingFeature.AddressingResponses.ANONYMOUS);
+            webServiceFeature.setAddressingRequired(true);
+
+            return webServiceFeature;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
+++ b/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
@@ -71,7 +71,8 @@ public class WinRmClientRecordedTest {
     }
 
     private void doRequest(URL url) {
-        WinRmClient.Builder builder = WinRmClient.builder(url, AuthSchemes.BASIC);
+        WinRmClientBuilder builder = WinRmClient.builder(url);
+        builder.authenticationScheme(AuthSchemes.BASIC);
 
         WinRmClient client = builder.build();
 
@@ -79,10 +80,8 @@ public class WinRmClientRecordedTest {
         StringWriter err = new StringWriter();
         int code;
 
-        try {
-            code = client.command("echo myline", out, err);
-        } finally {
-            client.disconnect();
+        try (ShellCommand shell = client.createShell()) {
+            code = shell.execute("echo myline", out, err);
         }
 
         assertEquals(out.toString(), "myline\r\n");

--- a/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
+++ b/client/src/test/java/io/cloudsoft/winrm4j/client/WinRmClientRecordedTest.java
@@ -132,7 +132,14 @@ public class WinRmClientRecordedTest {
 
             String contentType = request.getHeader("Content-Type");
             assertEquals(contentType, "application/soap+xml; action=\"" + next.getAction() + "\"; charset=UTF-8");
-            CompareMatcher.isIdenticalTo(next.getRequest())
+
+            // Similar comparison is when all differences that have been found are recoverable
+            // Namespace prefix differences are recoverable (see http://xmlunit.sourceforge.net/userguide/html/ar01s03.html#docleveldiff)
+            // For example the following are similar, but not identical:
+            // <ns1:a xmlns:ns1="test" />
+            // vs
+            // <a xmlns="test" />
+            CompareMatcher.isSimilarTo(next.getRequest())
                 .throwComparisonFailure()
                 .ignoreWhitespace()
                 .matches(requestDoc.getFirstChild());

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -245,7 +245,7 @@ public class WinRmTool {
         try (ShellCommand shell = client.createShell()) {
             int code = shell.execute(command, out, err);
             WinRmToolResponse winRmToolResponse = new WinRmToolResponse(out.toString(), err.toString(), code);
-            winRmToolResponse.setNumberOfReceiveCalls(client.getNumberOfReceiveCalls());
+            winRmToolResponse.setNumberOfReceiveCalls(shell.getNumberOfReceiveCalls());
             return winRmToolResponse;
         }
     }

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -13,7 +13,9 @@ import org.apache.http.client.config.AuthSchemes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.cloudsoft.winrm4j.client.ShellCommand;
 import io.cloudsoft.winrm4j.client.WinRmClient;
+import io.cloudsoft.winrm4j.client.WinRmClientBuilder;
 import io.cloudsoft.winrm4j.client.WinRmClientContext;
 
 /**
@@ -207,7 +209,8 @@ public class WinRmTool {
      * @since 0.2
      */
     public WinRmToolResponse executeCommand(String command) {
-        WinRmClient.Builder builder = WinRmClient.builder(address, authenticationScheme);
+        WinRmClientBuilder builder = WinRmClient.builder(address);
+        builder.authenticationScheme(authenticationScheme);
         if (operationTimeout != null) {
             builder.operationTimeout(operationTimeout);
         }
@@ -239,13 +242,11 @@ public class WinRmTool {
         StringWriter out = new StringWriter();
         StringWriter err = new StringWriter();
 
-        try {
-            int code = client.command(command, out, err);
+        try (ShellCommand shell = client.createShell()) {
+            int code = shell.execute(command, out, err);
             WinRmToolResponse winRmToolResponse = new WinRmToolResponse(out.toString(), err.toString(), code);
             winRmToolResponse.setNumberOfReceiveCalls(client.getNumberOfReceiveCalls());
             return winRmToolResponse;
-        } finally {
-            client.disconnect();
         }
     }
 

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmToolResponse.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmToolResponse.java
@@ -24,10 +24,13 @@ public class WinRmToolResponse {
         return statusCode;
     }
 
+    /** @deprecated since 0.6.0. Implementation detail, access will be removed in future versions */
     public void setNumberOfReceiveCalls(int numberOfReceiveCalls) {
         this.numberOfReceiveCalls = numberOfReceiveCalls;
     }
 
+    /** @deprecated since 0.6.0. Implementation detail, access will be removed in future versions */
+    @Deprecated
     public int getNumberOfReceiveCalls() {
         return numberOfReceiveCalls;
     }


### PR DESCRIPTION
A general refactoring, no new features added. Breaks up the huge `WinRmClient` file into several smaller pieces. Easier reviewed by looking at the individual commits.

This has been sitting around in a giant stash since before the 0.5.0 release, but decided it's too much to include in the release. I just split it into smaller, logical commits now. Some more to follow, mostly focusing on streamlining the tests.