### PR TITLE
Remove shared state (AddressingProperties) taking WinRmClient closer to thread safety

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -29,9 +29,8 @@ import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
-import org.apache.cxf.ws.addressing.AddressingProperties;
-import org.apache.cxf.ws.addressing.JAXWSAConstants;
-import org.apache.cxf.ws.addressing.VersionTransformer;
+import org.apache.cxf.ws.addressing.policy.MetadataConstants;
+import org.apache.cxf.ws.policy.PolicyConstants;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
@@ -41,6 +40,8 @@ import org.apache.http.config.RegistryBuilder;
 import org.apache.http.impl.auth.BasicSchemeFactory;
 import org.apache.http.impl.auth.KerberosSchemeFactory;
 import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.neethi.Policy;
+import org.apache.neethi.builders.PrimitiveAssertion;
 import org.w3c.dom.Element;
 
 import io.cloudsoft.winrm4j.client.ntlm.SpNegoNTLMSchemeFactory;
@@ -235,9 +236,9 @@ public class WinRmClient {
         List<Handler> handlerChain = Arrays.<Handler>asList(new StripShellResponseHandler());
         bp.getBinding().setHandlerChain(handlerChain);
 
-        Map<String, Object> requestContext = bp.getRequestContext();
-        AddressingProperties maps = new AddressingProperties(VersionTransformer.Names200408.WSA_NAMESPACE_NAME);
-        requestContext.put(JAXWSAConstants.CLIENT_ADDRESSING_PROPERTIES, maps);
+        Policy policy = new Policy();
+        policy.addAssertion(new PrimitiveAssertion(MetadataConstants.USING_ADDRESSING_2004_QNAME));
+        bp.getRequestContext().put(PolicyConstants.POLICY_OVERRIDE, policy);
 
         bp.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpoint);
 

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmFactory.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmFactory.java
@@ -1,17 +1,13 @@
 package io.cloudsoft.winrm4j.client;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 
-import javax.xml.ws.WebServiceFeature;
 import javax.xml.ws.spi.Provider;
 import javax.xml.ws.spi.ServiceDelegate;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
-import org.apache.cxf.feature.Feature;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
-import org.apache.cxf.ws.addressing.WSAddressingFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +93,6 @@ public class WinRmFactory {
         factory.getClientFactoryBean().getServiceFactory().setWsdlURL(WinRmService.WSDL_LOCATION);
         factory.setServiceName(WinRmService.SERVICE);
         factory.setEndpointName(WinRmService.WinRmPort);
-        factory.setFeatures(Arrays.asList((Feature)newMemberSubmissionAddressingFeature()));
         factory.setBus(bus);
         return factory.create(WinRm.class);
     }
@@ -107,33 +102,7 @@ public class WinRmFactory {
     }
 
     private static WinRm doCreateService_2_GetClient(WinRmService service) {
-        return service.getWinRmPort(
-                // * Adds WS-Addressing headers and uses the submission spec namespace
-                //   http://schemas.xmlsoap.org/ws/2004/08/addressing
-                newMemberSubmissionAddressingFeature());
-    }
-    
-    private static WebServiceFeature newMemberSubmissionAddressingFeature() {
-        /*
-         * Requires the following dependency so the feature is visible to maven.
-         * But is it included in the IBM dist?
-<dependency>
-    <groupId>com.sun.xml.ws</groupId>
-    <artifactId>jaxws-rt</artifactId>
-    <version>2.2.10</version>
-</dependency>
-         */
-        try {
-            // com.ibm.websphere.wsaddressing.jaxws21.SubmissionAddressingFeature for IBM java (available only in WebSphere?)
-
-            WSAddressingFeature webServiceFeature = new WSAddressingFeature();
-//            webServiceFeature.setResponses(WSAddressingFeature.AddressingResponses.ANONYMOUS);
-            webServiceFeature.setAddressingRequired(true);
-
-            return webServiceFeature;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return service.getWinRmPort();
     }
 
 }


### PR DESCRIPTION
AddressingProperties was shared between all requests, making it impossible to use the same WinRmClient concurrently. It stores things like the current action name (which we had to update because it takes the first one otherwise), the message id. We needed that so we can force CXF into using the 2004 version of the addressing namespace. The changes here take a different approach (creating a policy and setting a special assertion on it), causing CXF to create the AddressingProperties object per request.