### PR TITLE
[SECURITY] Bump cxf from 3.2.7 to 3.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <surefire.version>2.19.1</surefire.version>
     <testng.version>6.9.10</testng.version>
     <guava.version>18.0</guava.version>
-    <cxf.version>3.2.7</cxf.version>
+    <cxf.version>3.2.8</cxf.version>
     <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
     <httpcomponents.httpasyncclient.version>4.1.2</httpcomponents.httpasyncclient.version>
     <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>


### PR DESCRIPTION
Provides access to a security upgrade of  jackson-databind to 2.9.8 through the cxf-jaxrs feature.