### PR TITLE
issue-56: improve Kerberos authentication: obtain the tickets at runtime

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -99,11 +99,6 @@ public class WinRmClient implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(WinRmClient.class.getName());
 
     /**
-     * Name of the system property which define the login configuration file used for JAAS authentication.
-     */
-    private static final String JAAS_LOGIN_CONF_PROP = "java.security.auth.login.config";
-
-    /**
      * Object identifier of Kerberos as mechanism used by GSS for obtain the TGT.
      *
      * @see http://oid-info.com/get/1.2.840.113554.1.2.2
@@ -114,13 +109,6 @@ public class WinRmClient implements AutoCloseable {
      * Default JAAS configuration for Kerberos authentication.
      */
     private static final Configuration JAAS_KERB_LOGIN_CONF = new KerberosJaasConfiguration();
-
-    /**
-     * @return {@code true} if the JAAS configuration file for LoginModule is defined
-     */
-    private static boolean isJaasLoginConfigDefined() {
-        return System.getProperty(JAAS_LOGIN_CONF_PROP) != null;
-    }
 
     /**
      * Create a WinRmClient builder
@@ -302,11 +290,11 @@ public class WinRmClient implements AutoCloseable {
                  * 1) with SSO : if a JAAS configuration file is defined the authentication is done with an external
                  *    TGT get from the cache or a keyTab file or created after input credentials from prompt
                  *    (depending the configuration set in JAAS login configuration file).
-                 * 2) login : if no JAAS configuration is defined, a Kerberos authentication will be done with the
+                 * 2) login : if requested by the builder configuration, a Kerberos authentication will be done with the
                  *    credentials provided by the builder. The TGT obtained will be stored in the request context
                  *    in order to be used by the HttpAuthenticator to generate the Spnego token.
                  */
-                Credentials creds = authenticationScheme == AuthSchemes.KERBEROS && !isJaasLoginConfigDefined()
+                Credentials creds = authenticationScheme == AuthSchemes.KERBEROS && builder.requestNewKerberosTicket
                         ? getKerberosCreds(username, password)
                         : new NTCredentials(username, password, null, domain);
 

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -4,20 +4,29 @@ import java.io.Writer;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.security.PrivilegedAction;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.handler.Handler;
 import javax.xml.xpath.XPath;
@@ -28,6 +37,7 @@ import org.apache.cxf.Bus.BusState;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
+import org.apache.cxf.interceptor.security.NamePasswordCallbackHandler;
 import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
@@ -35,21 +45,30 @@ import org.apache.cxf.ws.addressing.policy.MetadataConstants;
 import org.apache.cxf.ws.policy.PolicyConstants;
 import org.apache.http.auth.AuthSchemeProvider;
 import org.apache.http.auth.Credentials;
+import org.apache.http.auth.KerberosCredentials;
 import org.apache.http.auth.NTCredentials;
 import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.impl.auth.BasicSchemeFactory;
 import org.apache.http.impl.auth.KerberosSchemeFactory;
-import org.apache.http.impl.auth.SPNegoSchemeFactory;
 import org.apache.neethi.Policy;
 import org.apache.neethi.builders.PrimitiveAssertion;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
 import io.cloudsoft.winrm4j.client.ntlm.SpNegoNTLMSchemeFactory;
 import io.cloudsoft.winrm4j.client.shell.EnvironmentVariable;
 import io.cloudsoft.winrm4j.client.shell.EnvironmentVariableList;
 import io.cloudsoft.winrm4j.client.shell.Shell;
+import io.cloudsoft.winrm4j.client.spnego.WsmanSPNegoSchemeFactory;
 import io.cloudsoft.winrm4j.client.transfer.ResourceCreated;
 import io.cloudsoft.winrm4j.client.wsman.Locale;
 import io.cloudsoft.winrm4j.client.wsman.OptionSetType;
@@ -76,6 +95,32 @@ public class WinRmClient implements AutoCloseable {
     private RetryingProxyHandler retryingHandler;
 
     private ShellCommand shellCommand;
+
+    private static final Logger LOG = LoggerFactory.getLogger(WinRmClient.class.getName());
+
+    /**
+     * Name of the system property which define the login configuration file used for JAAS authentication.
+     */
+    private static final String JAAS_LOGIN_CONF_PROP = "java.security.auth.login.config";
+
+    /**
+     * Object identifier of Kerberos as mechanism used by GSS for obtain the TGT.
+     *
+     * @see http://oid-info.com/get/1.2.840.113554.1.2.2
+     */
+    private static final String KERBEROS_OID = "1.2.840.113554.1.2.2";
+
+    /**
+     * Default JAAS configuration for Kerberos authentication.
+     */
+    private static final Configuration JAAS_KERB_LOGIN_CONF = new KerberosJaasConfiguration();
+
+    /**
+     * @return {@code true} if the JAAS configuration file for LoginModule is defined
+     */
+    private static boolean isJaasLoginConfigDefined() {
+        return System.getProperty(JAAS_LOGIN_CONF_PROP) != null;
+    }
 
     /**
      * Create a WinRmClient builder
@@ -252,12 +297,23 @@ public class WinRmClient implements AutoCloseable {
                 bp.getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, password);
                 break;
             case AuthSchemes.NTLM: case AuthSchemes.KERBEROS:
-                Credentials creds = new NTCredentials(username, password, null, domain);
+                /*
+                 * If Kerberos authentication is requested two modes can be used:
+                 * 1) with SSO : if a JAAS configuration file is defined the authentication is done with an external
+                 *    TGT get from the cache or a keyTab file or created after input credentials from prompt
+                 *    (depending the configuration set in JAAS login configuration file).
+                 * 2) login : if no JAAS configuration is defined, a Kerberos authentication will be done with the
+                 *    credentials provided by the builder. The TGT obtained will be stored in the request context
+                 *    in order to be used by the HttpAuthenticator to generate the Spnego token.
+                 */
+                Credentials creds = authenticationScheme == AuthSchemes.KERBEROS && !isJaasLoginConfigDefined()
+                        ? getKerberosCreds(username, password)
+                        : new NTCredentials(username, password, null, domain);
 
                 Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
                         .register(AuthSchemes.BASIC, new BasicSchemeFactory())
                         .register(AuthSchemes.SPNEGO,
-                                authenticationScheme.equals(AuthSchemes.NTLM) ? new SpNegoNTLMSchemeFactory() : new SPNegoSchemeFactory())
+                                authenticationScheme.equals(AuthSchemes.NTLM) ? new SpNegoNTLMSchemeFactory() : new WsmanSPNegoSchemeFactory())
                         .register(AuthSchemes.KERBEROS, new KerberosSchemeFactory())//
                         .build();
 
@@ -305,6 +361,86 @@ public class WinRmClient implements AutoCloseable {
             default:
                 throw new UnsupportedOperationException("No such authentication scheme " + authenticationScheme);
         }
+    }
+
+    /**
+     * Get new Kerberos credentials (i.e a TGT) with the username and password provided.
+     *
+     * @param username	name of the user to authenticate (format is UPN@DOMAIN)
+     * @param password	password of the user account
+     * @return credentials wrapping the TGT which will be used for obtaining the SPNego token
+     */
+    private static KerberosCredentials getKerberosCreds(String username, String password) {
+        // If the Kerberos Realm is in uppercases (which is the norm) and the domain in the UPN is in lowercases
+        // a KrbException: "Message stream modified" is thrown. To avoid this exception we force the UPN in uppercases
+        // Maybe this should be customizable with a parameter?
+        String canonizedUsername = username.trim().toUpperCase();
+        Subject subject = kerberosLogin(canonizedUsername, password);
+        GSSCredential userCred = Subject.doAs(subject, new PrivilegedAction<GSSCredential>() {
+            public GSSCredential run() {
+                try {
+                    GSSManager manager = GSSManager.getInstance();
+                    GSSName principal = manager.createName(canonizedUsername, null);
+                    Oid mechOid = new Oid(KERBEROS_OID);
+                    return manager.createCredential(principal, GSSContext.DEFAULT_LIFETIME, mechOid,
+                            GSSCredential.INITIATE_ONLY);
+                } catch (GSSException e) {
+                    throw new RuntimeException("Unable to create credential for user \"" //
+                            + username + "\" after login", e);
+                }
+            }
+        });
+        return new KerberosCredentials(userCred);
+    }
+
+    /**
+     * Authenticate the user with the provided password. The login send a request AS-REQ to the Authentication Server.
+     * The response will contain the TGT which will be store in the Subject.
+     *
+     * @param username	name of the user to authenticate (format is UPN@DOMAIN)
+     * @param password	password of the user account
+     * @return subject of the authenticated user
+     */
+    private static Subject kerberosLogin(String username, String password) {
+        CallbackHandler callbackHandler = new NamePasswordCallbackHandler(username, password);
+        Subject subject;
+        try {
+            LoginContext lc = new LoginContext("", null, callbackHandler, JAAS_KERB_LOGIN_CONF);
+            lc.login();
+            subject = lc.getSubject();
+        } catch (LoginException e) {
+            throw new RuntimeException("Exception occured while authenticate the user \"" //
+                    + username + "\" on the KDC", e);
+        }
+        LOG.debug("After kerberos login: subject=" + subject);
+        return subject;
+    }
+
+    /**
+     * Configuration for Kerberos login.<br>
+     * When this configuration is used (instead of the static JAAS config file) the purpose is to obtain a new TGT from
+     * the AS for the credentials provided to the {@link WinRmClientBuilder} and not to use an existing TGT from the
+     * cache. Thus this configuration disable the cache and the prompt in order to force the use of the credentials
+     * stored in the Subject after the login.
+     */
+    private static class KerberosJaasConfiguration extends Configuration {
+        private final AppConfigurationEntry[] appConfigurationEntries;
+
+        KerberosJaasConfiguration() {
+            Map<String, String> options = new HashMap<>();
+            options.put("doNoPrompt", "true");
+            options.put("client", "true");
+            options.put("isInitiator", "true");
+            options.put("useTicketCache", "false");
+            appConfigurationEntries = new AppConfigurationEntry[] { new AppConfigurationEntry(
+                    "com.sun.security.auth.module.Krb5LoginModule", LoginModuleControlFlag.REQUIRED, options) };
+        }
+
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            return appConfigurationEntries;
+        }
+
     }
 
     /**

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -35,6 +35,7 @@ public class WinRmClientBuilder {
     protected SSLSocketFactory sslSocketFactory;
     
     protected SSLContext sslContext;
+    protected boolean requestNewKerberosTicket;
     
     WinRmClientBuilder(String endpoint) {
         this(toUrlUnchecked(WinRmClient.checkNotNull(endpoint, "endpoint")));
@@ -163,6 +164,16 @@ public class WinRmClientBuilder {
      */
     public WinRmClientBuilder context(WinRmClientContext context) {
         this.context = context;
+        return this;
+    }
+
+    /**
+     * Set this parameter to {@code true} for requesting from the KDC a fresh Kerberos TGT with credentials set to the builder.
+     * In this case the configuration defined in the JAAS configuration file will be ignored.
+     * By default this parameter is set to {@code false}. 
+     */
+    public WinRmClientBuilder requestNewKerberosTicket(boolean requestNewKerberosTicket) {
+        this.requestNewKerberosTicket = requestNewKerberosTicket;
         return this;
     }
 

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/spnego/WsmanSPNegoScheme.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/spnego/WsmanSPNegoScheme.java
@@ -1,0 +1,53 @@
+package io.cloudsoft.winrm4j.client.spnego;
+
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.KerberosCredentials;
+import org.apache.http.impl.auth.SPNegoScheme;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+
+/**
+ * The {@link SPNegoScheme} use the scheme of the URI (HTTP or HTTPS) to build the SPN of WinRM.
+ * Thus when we access to the HTTPS listener of the WinRM service the SPN built is HTTPS/HOSTNAME which doesn't exist.
+ * When WinRM is configured the SPN automatically added is: WSMAN/HOSTNAME.
+ */
+public class WsmanSPNegoScheme extends SPNegoScheme {
+
+    public WsmanSPNegoScheme(final boolean stripPort, final boolean useCanonicalHostname) {
+        super(stripPort, useCanonicalHostname);
+    }
+    
+    /**
+     * Copied form {@link org.apache.http.impl.auth.GGSSchemeBase#generateGSSToken}.
+     * The variable "service" must be set to "WSMAN" but this variable is private.
+     */
+    @Override
+    protected byte[] generateGSSToken(
+            final byte[] input, final Oid oid, final String authServer,
+            final Credentials credentials) throws GSSException {
+        byte[] inputBuff = input;
+        if (inputBuff == null) {
+            inputBuff = new byte[0];
+        }
+        final GSSManager manager = getManager();
+        final GSSName serverName = manager.createName("WSMAN" + "@" + authServer, GSSName.NT_HOSTBASED_SERVICE);
+
+        final GSSCredential gssCredential;
+        if (credentials instanceof KerberosCredentials) {
+            gssCredential = ((KerberosCredentials) credentials).getGSSCredential();
+        } else {
+            gssCredential = null;
+        }
+
+        final GSSContext gssContext = manager.createContext(
+                serverName.canonicalize(oid), oid, gssCredential, GSSContext.DEFAULT_LIFETIME);
+        gssContext.requestMutualAuth(true);
+        gssContext.requestCredDeleg(true);
+        return gssContext.initSecContext(inputBuff, 0, inputBuff.length);
+    }
+
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/spnego/WsmanSPNegoSchemeFactory.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/spnego/WsmanSPNegoSchemeFactory.java
@@ -1,0 +1,17 @@
+package io.cloudsoft.winrm4j.client.spnego;
+
+import org.apache.http.auth.AuthScheme;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.protocol.HttpContext;
+
+public class WsmanSPNegoSchemeFactory extends SPNegoSchemeFactory {
+    
+    public WsmanSPNegoSchemeFactory() {
+        super(true, true);
+    }
+    
+    @Override
+    public AuthScheme create(final HttpContext context) {
+        return new WsmanSPNegoScheme(isStripPort(), isUseCanonicalHostname());
+    }    
+}

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -50,6 +50,7 @@ public class WinRmTool {
     private final SSLSocketFactory sslSocketFactory;
     private final SSLContext sslContext;
     private final WinRmClientContext context;
+    private final boolean requestNewKerberosTicket;
 
     public static class Builder {
         private String authenticationScheme = AuthSchemes.NTLM;
@@ -66,6 +67,7 @@ public class WinRmTool {
         private SSLSocketFactory sslSocketFactory;
         private SSLContext sslContext;
         private WinRmClientContext context;
+        private boolean requestNewKerberosTicket;
 
         private static final Pattern matchPort = Pattern.compile(".*:(\\d+)$");
 
@@ -139,13 +141,18 @@ public class WinRmTool {
             this.context = context;
             return this;
         }
+        
+        public Builder requestNewKerberosTicket(boolean requestNewKerberosTicket) {
+            this.requestNewKerberosTicket = requestNewKerberosTicket;
+            return this;
+        }
 
         public WinRmTool build() {
             return new WinRmTool(getEndpointUrl(address, useHttps, port),
                     domain, username, password, authenticationScheme,
                     disableCertificateChecks, workingDirectory,
                     environment, hostnameVerifier, sslSocketFactory, sslContext,
-                    context);
+                    context, requestNewKerberosTicket);
         }
 
         // TODO remove arguments when method WinRmTool.connect() is removed
@@ -184,7 +191,8 @@ public class WinRmTool {
             String password, String authenticationScheme,
             boolean disableCertificateChecks, String workingDirectory,
             Map<String, String> environment, HostnameVerifier hostnameVerifier,
-            SSLSocketFactory sslSocketFactory, SSLContext sslContext, WinRmClientContext context) {
+            SSLSocketFactory sslSocketFactory, SSLContext sslContext, WinRmClientContext context,
+            boolean requestNewKerberosTicket) {
         this.disableCertificateChecks = disableCertificateChecks;
         this.address = address;
         this.domain = domain;
@@ -197,6 +205,7 @@ public class WinRmTool {
         this.sslSocketFactory = sslSocketFactory;
         this.sslContext = sslContext;
         this.context = context;
+        this.requestNewKerberosTicket = requestNewKerberosTicket;
     }
 
     /**
@@ -272,6 +281,9 @@ public class WinRmTool {
         }
         if (context != null) {
             builder.context(context);
+        }
+        if (requestNewKerberosTicket) {
+            builder.requestNewKerberosTicket(requestNewKerberosTicket);
         }
 
         StringWriter out = new StringWriter();


### PR DESCRIPTION
The solution proposed by Arulanand in the issue https://github.com/cloudsoft/winrm4j/issues/56#issuecomment-300424088 works but I found some drawbacks during tests : a new TGT and a new service ticket are requested to the KDC for each SOAP requests.
For executing a command we have to send 5 SOAP requests to the WinRM Service : Create, Command, Receive, Signal, Delete.  So with this solution (which use the SpnegoAuthSupplier) that will imply to generate 10 tickets (5 TGT and 5 ST) as we can see on the following capture :
![winrm4j-issue-56-solution-1](https://user-images.githubusercontent.com/2385140/58839416-0e849e00-8662-11e9-8b78-7f110c63e998.png)

This PR proposes an alternate solution which seems better for my use case : only one TGT and one ticket service are generated:
![winrm4j-issue-56-solution-2](https://user-images.githubusercontent.com/2385140/58839421-13495200-8662-11e9-9e8c-10bc406a6990.png)

The solution implemented by this PR doesn't modify the previous behaviour when a JAAS login config file is defined by the system property "java.security.auth.login.config".
In this case the TGT continue to be grabbed from an external source (depending of the options set in the JAAS login config file) : the cache, a keyTab file or input from prompt.

This PR add the possibility to use SPNego/Kerberos authentication without external credentials but only with username and password provided to WinRmClient.
If no JAAS login config file is defined a Kerberos login will be executed to obtain from the Authentication Service one fresh TGT. 
This credentials is stored in the context of the message in order to be available to generate one SPNego token only when the WinRM services responds by a 401 Unauthorized.



