### PR TITLE
issue-67: parametrize the behaviour when the operation timeout expired

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -68,6 +69,7 @@ public class WinRmClient implements AutoCloseable {
 
     // Can be changed throughout object's lifetime, but deprecated
     private String operationTimeout;
+    private Predicate<String> retryReceiveAfterOperationTimeout;
 
     private final WinRmClientContext context;
     private final boolean cleanupContext;
@@ -156,6 +158,7 @@ public class WinRmClient implements AutoCloseable {
         this.workingDirectory = builder.workingDirectory;
         this.locale = builder.locale;
         this.operationTimeout = toDuration(builder.operationTimeout);
+        this.retryReceiveAfterOperationTimeout = builder.retryReceiveAfterOperationTimeout;
         this.environment = builder.environment;
 
         if (builder.context != null) {
@@ -344,7 +347,7 @@ public class WinRmClient implements AutoCloseable {
         ResourceCreated resourceCreated = winrm.create(shell, RESOURCE_URI, MAX_ENVELOPER_SIZE, operationTimeout, locale, optSetCreate);
         String shellId = getShellId(resourceCreated);
 
-        return new ShellCommand(winrm, shellId, operationTimeout, locale);
+        return new ShellCommand(winrm, shellId, operationTimeout, retryReceiveAfterOperationTimeout, locale);
     }
 
     private static String getShellId(ResourceCreated resourceCreated) {

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -3,6 +3,7 @@ package io.cloudsoft.winrm4j.client;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -26,6 +27,7 @@ public class WinRmClientBuilder {
     protected String workingDirectory;
     protected Locale locale;
     protected long operationTimeout;
+    protected Predicate<String> retryReceiveAfterOperationTimeout;
     protected Long receiveTimeout;
     protected int retriesForConnectionFailures;
     protected Map<String, String> environment;
@@ -45,6 +47,7 @@ public class WinRmClientBuilder {
         authenticationScheme(AuthSchemes.NTLM);
         locale(DEFAULT_LOCALE);
         operationTimeout(DEFAULT_OPERATION_TIMEOUT);
+        retryReceiveAfterOperationTimeout(alwaysRetryReceiveAfterOperationTimeout());
         retriesForConnectionFailures(DEFAULT_RETRIES_FOR_CONNECTION_FAILURES);
     }
 
@@ -88,6 +91,24 @@ public class WinRmClientBuilder {
     public WinRmClientBuilder operationTimeout(long operationTimeout) {
         this.operationTimeout = WinRmClient.checkNotNull(operationTimeout, "operationTimeout");
         return this;
+    }
+
+    /**
+     * @param retryReceiveAfterOperationTimeout define if a new Receive request will be send when the server returns
+     *      a fault with the code {@link ShellCommand#WSMAN_FAULT_CODE_OPERATION_TIMEOUT_EXPIRED}.
+     *        Default value {@link #ALWAYS_RETRY_AFTER_OPERATION_TIMEOUT_EXPIRED}.
+     */
+    public WinRmClientBuilder retryReceiveAfterOperationTimeout(Predicate<String> retryReceiveAfterOperationTimeout) {
+        this.retryReceiveAfterOperationTimeout = retryReceiveAfterOperationTimeout;
+        return this;
+    }
+
+    public static Predicate<String> alwaysRetryReceiveAfterOperationTimeout() {
+        return x -> true;
+    }
+
+    public static Predicate<String> neverRetryReceiveAfterOperationTimeout() {
+        return x -> false;
     }
 
     /**

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -4,6 +4,7 @@ import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,6 +43,7 @@ public class WinRmTool {
     private final String password;
     private final String authenticationScheme;
     private Long operationTimeout;
+    private Predicate<String> retryReceiveAfterOperationTimeout;
     private Integer retriesForConnectionFailures;
     private final boolean disableCertificateChecks;
     private final String workingDirectory;
@@ -227,6 +229,18 @@ public class WinRmTool {
         this.operationTimeout = operationTimeout;
     }
 
+    public void setRetryReceiveAfterOperationTimeout(Predicate<String> retryReceiveAfterOperationTimeout) {
+        this.retryReceiveAfterOperationTimeout = retryReceiveAfterOperationTimeout;
+    }
+
+    public void alwaysRetryReceiveAfterOperationTimeout() {
+        setRetryReceiveAfterOperationTimeout(WinRmClientBuilder.alwaysRetryReceiveAfterOperationTimeout());
+    }
+
+    public void neverRetryReceiveAfterOperationTimeout() {
+        setRetryReceiveAfterOperationTimeout(WinRmClientBuilder.neverRetryReceiveAfterOperationTimeout());
+    }
+
     public void setRetriesForConnectionFailures(Integer retriesForConnectionFailures) {
         this.retriesForConnectionFailures = retriesForConnectionFailures;
     }
@@ -244,6 +258,9 @@ public class WinRmTool {
         builder.authenticationScheme(authenticationScheme);
         if (operationTimeout != null) {
             builder.operationTimeout(operationTimeout);
+        }
+        if (retryReceiveAfterOperationTimeout != null) {
+            builder.retryReceiveAfterOperationTimeout(retryReceiveAfterOperationTimeout);
         }
         if (username != null && password != null) {
             builder.credentials(domain, username, password);


### PR DESCRIPTION
This PR proposes to add a parameter for confguring the behaviour when the operation timeout expired.

As explained by neykov in the issue https://github.com/cloudsoft/winrm4j/issues/67#issuecomment-315346167 the specification advice to post new Receive requests for waiting the complete execution of the command.:
[WSMan: 3.1.4.14 Receive](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wsmv/50cc2c38-e094-4d59-aec2-39e09f314862)
> If no output is available before the wsman:OperationTimeout expires, the server MUST return a WSManFault with the Code attribute equal to "2150858793". When the client receives this fault, it SHOULD issue another Receive request. The client SHOULD continue to issue Receive messages as soon as the previous ReceiveResponse has been received.

But the specification saids that "the client SHOULD" and not "MUST". In some use cases it's not suitable to continue thus this PR proposes to let the choice to the application.

By default the behaviour is unmodified and the ShellCommand continues to send a new Receive after an OperationTimeout fault.

Instead of use a simple `boolean` to parametrize the loop of retries this PR use a `Predicate` in order to let the possibility to the application to implement more complex scenario (e.g with a counter).  
 