### PR TITLE
Parametrize the retry policy applied after a connection failure

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -167,7 +167,7 @@ public class WinRmClient implements AutoCloseable {
         }
 
         WinRm service = getService(builder);
-        retryingHandler = new RetryingProxyHandler(service, builder.retriesForConnectionFailures);
+        retryingHandler = new RetryingProxyHandler(service, builder.afterConnectionFailureRetryPolicy);
         this.winrm = (WinRm) Proxy.newProxyInstance(WinRm.class.getClassLoader(),
                 new Class[] {WinRm.class, BindingProvider.class},
                 retryingHandler);

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -3,6 +3,7 @@ package io.cloudsoft.winrm4j.client;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -10,12 +11,19 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.http.client.config.AuthSchemes;
 
+import io.cloudsoft.winrm4j.client.retry.RetryPolicy;
+import io.cloudsoft.winrm4j.client.retry.SimpleCounterRetryPolicy;
 import io.cloudsoft.winrm4j.client.wsman.Locale;
 
 public class WinRmClientBuilder {
     private static final java.util.Locale DEFAULT_LOCALE = java.util.Locale.US;
     private static final Long DEFAULT_OPERATION_TIMEOUT = 60l * 1000l;
     private static final int DEFAULT_RETRIES_FOR_CONNECTION_FAILURES = 1;
+
+    /**
+     * Duration in seconds applied by default for the sleep between 2 retries after a connection failure.
+     */
+    private static final long DEFAULT_PAUSE_BETWEEN_RETRIES = 5;
 
     protected WinRmClientContext context;
     protected final URL endpoint;
@@ -27,7 +35,7 @@ public class WinRmClientBuilder {
     protected Locale locale;
     protected long operationTimeout;
     protected Long receiveTimeout;
-    protected int retriesForConnectionFailures;
+    protected RetryPolicy afterConnectionFailureRetryPolicy;
     protected Map<String, String> environment;
 
     protected boolean disableCertificateChecks;
@@ -92,16 +100,26 @@ public class WinRmClientBuilder {
 
     /**
      * @param retriesConnectionFailures How many times to retry the command before giving up in case of failure (exception).
-     *        Default is 16.
+     *        Default is 1.
+     * @deprecated replaced by {@link #afterConnectionFailureRetryPolicy(RetryPolicy)}
      */
+    @Deprecated
     public WinRmClientBuilder retriesForConnectionFailures(int retriesConnectionFailures) {
         if (retriesConnectionFailures < 1) {
             throw new IllegalArgumentException("retriesConnectionFailure should be one or more");
         }
-        this.retriesForConnectionFailures = retriesConnectionFailures;
+        afterConnectionFailureRetryPolicy(simpleCounterRetryPolicy(retriesConnectionFailures));
         return this;
     }
 
+    public WinRmClientBuilder afterConnectionFailureRetryPolicy(RetryPolicy afterConnectionFailureRetryPolicy) {
+        this.afterConnectionFailureRetryPolicy = afterConnectionFailureRetryPolicy;
+        return this;
+    }
+
+    public static RetryPolicy simpleCounterRetryPolicy(int total) {
+        return new SimpleCounterRetryPolicy(total, DEFAULT_PAUSE_BETWEEN_RETRIES, TimeUnit.SECONDS);
+    }
 
     /**
      * @param disableCertificateChecks Skip trusted certificate and domain (CN) checks.

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/retry/DefaultRetryDecision.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/retry/DefaultRetryDecision.java
@@ -1,0 +1,24 @@
+package io.cloudsoft.winrm4j.client.retry;
+
+/**
+ * Immutable Value Object to carry the decision make by the retry policy.
+ */
+public class DefaultRetryDecision implements RetryDecision {
+    private final boolean retry;
+    private final long pause;
+
+    DefaultRetryDecision(boolean retry, long pause) {
+        this.retry = retry;
+        this.pause = pause;
+    }
+
+    @Override
+    public boolean retry() {
+        return retry;
+    }
+
+    @Override
+    public long pause() {
+        return pause;
+    }
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/retry/RetryDecision.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/retry/RetryDecision.java
@@ -1,0 +1,16 @@
+package io.cloudsoft.winrm4j.client.retry;
+
+/**
+ * Decision about apply a retry after an exception
+ */
+public interface RetryDecision {
+    /**
+     * @return {@code true} if a new retry must be done
+     */
+    boolean retry();
+
+    /**
+     * @return duration in milliseconds of the sleep before the next retry
+     */
+    long pause();
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/retry/RetryPolicy.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/retry/RetryPolicy.java
@@ -1,0 +1,23 @@
+package io.cloudsoft.winrm4j.client.retry;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Policy to decide if a retry must be done.
+ */
+public interface RetryPolicy extends Function<Throwable, RetryDecision> {
+
+    /**
+     * @return total number of retries if known
+     */
+    default Optional<Integer> total() {
+        return Optional.empty();
+    }
+
+    /**
+     * Reset the state of the policy. This method MUST be called before enter the loop of retries.
+     */
+    default void clear() {
+    }
+}

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/retry/SimpleCounterRetryPolicy.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/retry/SimpleCounterRetryPolicy.java
@@ -1,0 +1,39 @@
+package io.cloudsoft.winrm4j.client.retry;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Basic implementation of a retry policy based on a simple counter. The duration of the pause is static.
+ */
+public class SimpleCounterRetryPolicy implements RetryPolicy {
+    private final long pause;
+    private final int total;
+    private int counter;
+
+    /**
+     * @param total         total number of retries
+     * @param pause         duration of the sleep between each retries
+     * @param pauseUnit     unit of the duration
+     */
+    public SimpleCounterRetryPolicy(int total, long pause, TimeUnit pauseUnit) {
+        this.total = total;
+        this.pause = pauseUnit.toMillis(pause);
+    }
+
+    @Override
+    public Optional<Integer> total() {
+        return Optional.of(total);
+    }
+
+    @Override
+    public void clear() {
+        counter = 0;
+    }
+
+    @Override
+    public RetryDecision apply(Throwable t) {
+        counter++;
+        return new DefaultRetryDecision(counter <= total, pause);
+    }
+}

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -19,6 +19,7 @@ import io.cloudsoft.winrm4j.client.ShellCommand;
 import io.cloudsoft.winrm4j.client.WinRmClient;
 import io.cloudsoft.winrm4j.client.WinRmClientBuilder;
 import io.cloudsoft.winrm4j.client.WinRmClientContext;
+import io.cloudsoft.winrm4j.client.retry.RetryPolicy;
 
 /**
  * Tool for executing commands over WinRM.
@@ -42,7 +43,7 @@ public class WinRmTool {
     private final String password;
     private final String authenticationScheme;
     private Long operationTimeout;
-    private Integer retriesForConnectionFailures;
+    private RetryPolicy afterConnectionFailureRetryPolicy;
     private final boolean disableCertificateChecks;
     private final String workingDirectory;
     private final Map<String, String> environment;
@@ -227,8 +228,15 @@ public class WinRmTool {
         this.operationTimeout = operationTimeout;
     }
 
+    /**
+     * Convenience method to define a simple retry policy with the default pause.
+     */
     public void setRetriesForConnectionFailures(Integer retriesForConnectionFailures) {
-        this.retriesForConnectionFailures = retriesForConnectionFailures;
+        setAfterConnectionFailureRetryPolicy(WinRmClientBuilder.simpleCounterRetryPolicy(retriesForConnectionFailures));
+    }
+
+    public void setAfterConnectionFailureRetryPolicy(RetryPolicy afterConnectionFailureRetryPolicy) {
+        this.afterConnectionFailureRetryPolicy = afterConnectionFailureRetryPolicy;
     }
 
     /**
@@ -267,8 +275,8 @@ public class WinRmTool {
         if (environment != null) {
             builder.environment(environment);
         }
-        if (retriesForConnectionFailures != null) {
-            builder.retriesForConnectionFailures(retriesForConnectionFailures);
+        if (afterConnectionFailureRetryPolicy != null) {
+            builder.afterConnectionFailureRetryPolicy(afterConnectionFailureRetryPolicy);
         }
         if (context != null) {
             builder.context(context);


### PR DESCRIPTION
When a SOAP request throws an exception of type `WebServiceException` the request is retried by Winrm4j at least one time.
This retry policy is applied by the invocation handler `RetryingProxyHandler` for all SOAP operations of the WinRM service (excepted for the "command" operation).
It's possible to configure the number of retries on the `WinRmTool` with the setter `setRetriesForConnectionFailures` but isn't possible to disable this feature because the `WinRmClientBuilder` throws an IllegalArgumentException if the `retriesConnectionFailure` is less than one.

Like for the OperationTimeout (please see issue https://github.com/cloudsoft/winrm4j/pull/106) it seems to me desirable that this behaviour could be configured by the application.

This PR suggests the following improvements:
- configuration of the retry policy with a function (instead of just a simple integer) in order to offer the possibility to address more complex scenarii
- allowed the option to do no retry at all
- don't execute the last sleep in the loop of retries (useless because after the exception is propagate)
- give the choice of the duration for each sleep (until now the pause was hardcoded to 5 seconds)

The default configuration stays unmodified with one retry.
