### PR TITLE
Configure socket timeouts

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -218,6 +218,7 @@ public class WinRmClient implements AutoCloseable {
         HostnameVerifier hostnameVerifier = builder.hostnameVerifier;
         SSLSocketFactory sslSocketFactory = builder.sslSocketFactory;
         SSLContext sslContext = builder.sslContext;
+        long connectionTimeout = builder.connectionTimeout;
         long receiveTimeout;
         if (builder.receiveTimeout != null) {
             receiveTimeout = builder.receiveTimeout;
@@ -297,6 +298,7 @@ public class WinRmClient implements AutoCloseable {
                 }
                 HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
                 httpClientPolicy.setAllowChunking(false);
+                httpClientPolicy.setConnectionTimeout(connectionTimeout);
                 httpClientPolicy.setReceiveTimeout(receiveTimeout);
 
                 httpClient.setClient(httpClientPolicy);

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -3,6 +3,7 @@ package io.cloudsoft.winrm4j.client;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -14,6 +15,15 @@ import io.cloudsoft.winrm4j.client.wsman.Locale;
 
 public class WinRmClientBuilder {
     private static final java.util.Locale DEFAULT_LOCALE = java.util.Locale.US;
+    /**
+     * Timeout applied by default on client side for the opening of the socket (0 meaning infinite waiting).
+     */
+    private static final Long DEFAULT_CONNECTION_TIMEOUT = 0l;
+    /**
+     * Timeout applied by default on client side for the reading of the socket ({@code null} meaning automatically calculated from
+     * the{@link #operationTimeout} by adding to it one minute).
+     */
+    private static final Long DEFAULT_RECEIVE_TIMEOUT = null;
     private static final Long DEFAULT_OPERATION_TIMEOUT = 60l * 1000l;
     private static final int DEFAULT_RETRIES_FOR_CONNECTION_FAILURES = 1;
 
@@ -26,6 +36,7 @@ public class WinRmClientBuilder {
     protected String workingDirectory;
     protected Locale locale;
     protected long operationTimeout;
+    protected Long connectionTimeout;
     protected Long receiveTimeout;
     protected int retriesForConnectionFailures;
     protected Map<String, String> environment;
@@ -45,6 +56,8 @@ public class WinRmClientBuilder {
         authenticationScheme(AuthSchemes.NTLM);
         locale(DEFAULT_LOCALE);
         operationTimeout(DEFAULT_OPERATION_TIMEOUT);
+        connectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+        receiveTimeout(DEFAULT_RECEIVE_TIMEOUT);
         retriesForConnectionFailures(DEFAULT_RETRIES_FOR_CONNECTION_FAILURES);
     }
 
@@ -89,6 +102,30 @@ public class WinRmClientBuilder {
         this.operationTimeout = WinRmClient.checkNotNull(operationTimeout, "operationTimeout");
         return this;
     }
+
+   /**
+    * Timeout applied to connect the socket.
+    *
+    * @param connectionTimeout in milliseconds
+    *                         default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_TIMEOUT}
+    * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setConnectionTimeout-long-">HTTPClientPolicy#setConnectionTimeout</a>
+    */
+    public WinRmClientBuilder connectionTimeout(Long connectionTimeout) {
+        this.connectionTimeout = Objects.requireNonNull(connectionTimeout, "connectionTimeout");
+        return this;
+    }
+
+    /**
+     * Timeout applied to read the socket.
+     *
+     * @param receiveTimeout in milliseconds
+     *                         default value {@link WinRmClientBuilder#DEFAULT_RECEIVE_TIMEOUT}
+     * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setReceiveTimeout-long-">HTTPClientPolicy#setReceiveTimeout</a>
+     */
+     public WinRmClientBuilder receiveTimeout(Long receiveTimeout) {
+         this.receiveTimeout = receiveTimeout;
+         return this;
+     }
 
     /**
      * @param retriesConnectionFailures How many times to retry the command before giving up in case of failure (exception).

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -43,6 +43,8 @@ public class WinRmTool {
     private final String authenticationScheme;
     private Long operationTimeout;
     private Integer retriesForConnectionFailures;
+    private Long connectionTimeout;
+    private Long receiveTimeout;
     private final boolean disableCertificateChecks;
     private final String workingDirectory;
     private final Map<String, String> environment;
@@ -227,6 +229,26 @@ public class WinRmTool {
         this.operationTimeout = operationTimeout;
     }
 
+	/**
+	 * Update connectionTimeout
+	 *
+	 * @param connectionTimeout in milliseconds
+	 *                         default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_TIMEOUT}
+	 */
+	public void setConnectionTimeout(Long connectionTimeout) {
+		this.connectionTimeout = connectionTimeout;
+	}
+
+	/**
+	 * Update receiveTimeout
+	 *
+	 * @param receiveTimeout in milliseconds
+	 *                         default value {@link WinRmClientBuilder#DEFAULT_RECEIVE_TIMEOUT}
+	 */
+	public void setReceiveTimeout(Long receiveTimeout) {
+		this.receiveTimeout = receiveTimeout;
+	}
+
     public void setRetriesForConnectionFailures(Integer retriesForConnectionFailures) {
         this.retriesForConnectionFailures = retriesForConnectionFailures;
     }
@@ -244,6 +266,12 @@ public class WinRmTool {
         builder.authenticationScheme(authenticationScheme);
         if (operationTimeout != null) {
             builder.operationTimeout(operationTimeout);
+        }
+        if (connectionTimeout != null) {
+            builder.connectionTimeout(connectionTimeout);
+        }
+        if (receiveTimeout != null) {
+            builder.receiveTimeout(receiveTimeout);
         }
         if (username != null && password != null) {
             builder.credentials(domain, username, password);


### PR DESCRIPTION
This PR allows to configure the two timeouts applied on the socket: for connection and read (SO_TIMEOUT).

It's desirable to be able to configure the connection timeout to avoid waiting until the TCP handshake timeout applied by the system (e.g. on Windows 21 seconds by default) for use cases where the remote host can be down.
The configuration of the receive timeout is also included even it was not really necessary because a default value was already automaically calculated from the operationTimeout (by adding 1 minute).
