### PR TITLE
Builds on PR #108

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -15,8 +15,8 @@ import java.util.Map.Entry;
 import java.util.function.Predicate;
 
 import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.xml.ws.BindingProvider;
@@ -222,6 +222,7 @@ public class WinRmClient implements AutoCloseable {
         SSLSocketFactory sslSocketFactory = builder.sslSocketFactory;
         SSLContext sslContext = builder.sslContext;
         long connectionTimeout = builder.connectionTimeout;
+        long connectionRequestTimeout = builder.connectionRequestTimeout;
         long receiveTimeout;
         if (builder.receiveTimeout != null) {
             receiveTimeout = builder.receiveTimeout;
@@ -302,6 +303,7 @@ public class WinRmClient implements AutoCloseable {
                 HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
                 httpClientPolicy.setAllowChunking(false);
                 httpClientPolicy.setConnectionTimeout(connectionTimeout);
+                httpClientPolicy.setConnectionRequestTimeout(connectionRequestTimeout);
                 httpClientPolicy.setReceiveTimeout(receiveTimeout);
 
                 httpClient.setClient(httpClientPolicy);

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -221,6 +221,7 @@ public class WinRmClient implements AutoCloseable {
         HostnameVerifier hostnameVerifier = builder.hostnameVerifier;
         SSLSocketFactory sslSocketFactory = builder.sslSocketFactory;
         SSLContext sslContext = builder.sslContext;
+        long connectionTimeout = builder.connectionTimeout;
         long receiveTimeout;
         if (builder.receiveTimeout != null) {
             receiveTimeout = builder.receiveTimeout;
@@ -300,6 +301,7 @@ public class WinRmClient implements AutoCloseable {
                 }
                 HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
                 httpClientPolicy.setAllowChunking(false);
+                httpClientPolicy.setConnectionTimeout(connectionTimeout);
                 httpClientPolicy.setReceiveTimeout(receiveTimeout);
 
                 httpClient.setClient(httpClientPolicy);

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -5,7 +5,6 @@ import java.net.URL;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.concurrent.TimeUnit;
-import java.util.Objects;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -22,13 +21,18 @@ public class WinRmClientBuilder {
     /**
      * Timeout applied by default on client side for the opening of the socket (0 meaning infinite waiting).
      */
-    private static final Long DEFAULT_CONNECTION_TIMEOUT = 0l;
+    // Default matches org.apache.cxf.transports.http.configuration.HTTPClientPolicy.getConnectionTimeout()
+    private static final long DEFAULT_CONNECTION_TIMEOUT = 30L * 1000L;
+    
+    // Default matches org.apache.cxf.transports.http.configuration.HTTPClientPolicy.getConnectionRequestTimeout()
+    private static final long DEFAULT_CONNECTION_REQUEST_TIMEOUT = 60L * 1000L;
+    
     /**
      * Timeout applied by default on client side for the reading of the socket ({@code null} meaning automatically calculated from
      * the{@link #operationTimeout} by adding to it one minute).
      */
     private static final Long DEFAULT_RECEIVE_TIMEOUT = null;
-    private static final Long DEFAULT_OPERATION_TIMEOUT = 60l * 1000l;
+    private static final Long DEFAULT_OPERATION_TIMEOUT = 60L * 1000L;
     private static final int DEFAULT_RETRIES_FOR_CONNECTION_FAILURES = 1;
 
     /**
@@ -46,7 +50,8 @@ public class WinRmClientBuilder {
     protected Locale locale;
     protected long operationTimeout;
     protected Predicate<String> retryReceiveAfterOperationTimeout;
-    protected Long connectionTimeout;
+    protected long connectionTimeout;
+    protected long connectionRequestTimeout;
     protected Long receiveTimeout;
     protected RetryPolicy failureRetryPolicy;
     protected Map<String, String> environment;
@@ -68,6 +73,7 @@ public class WinRmClientBuilder {
         operationTimeout(DEFAULT_OPERATION_TIMEOUT);
         retryReceiveAfterOperationTimeout(alwaysRetryReceiveAfterOperationTimeout());
         connectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+        connectionRequestTimeout(DEFAULT_CONNECTION_REQUEST_TIMEOUT);
         receiveTimeout(DEFAULT_RECEIVE_TIMEOUT);
         retriesForConnectionFailures(DEFAULT_RETRIES_FOR_CONNECTION_FAILURES);
     }
@@ -110,7 +116,7 @@ public class WinRmClientBuilder {
      *                         default value {@link WinRmClient.Builder#DEFAULT_OPERATION_TIMEOUT}
      */
     public WinRmClientBuilder operationTimeout(long operationTimeout) {
-        this.operationTimeout = WinRmClient.checkNotNull(operationTimeout, "operationTimeout");
+        this.operationTimeout = operationTimeout;
         return this;
     }
 
@@ -121,10 +127,22 @@ public class WinRmClientBuilder {
     *                         default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_TIMEOUT}
     * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setConnectionTimeout-long-">HTTPClientPolicy#setConnectionTimeout</a>
     */
-    public WinRmClientBuilder connectionTimeout(Long connectionTimeout) {
-        this.connectionTimeout = Objects.requireNonNull(connectionTimeout, "connectionTimeout");
+    public WinRmClientBuilder connectionTimeout(long connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
         return this;
     }
+
+    /**
+     * Timeout applied to requesting a connection from the connection manager.
+     *
+     * @param connectionRequestTimeout in milliseconds
+     *                                 default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_REQUEST_TIMEOUT}
+     * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setConnectionRequestTimeout-long-">HTTPClientPolicy#setConnectionRequestTimeout</a>
+     */
+     public WinRmClientBuilder connectionRequestTimeout(long connectionRequestTimeout) {
+         this.connectionRequestTimeout = connectionRequestTimeout;
+         return this;
+     }
 
     /**
      * Timeout applied to read the socket.

--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClientBuilder.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.concurrent.TimeUnit;
+import java.util.Objects;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -18,6 +19,15 @@ import io.cloudsoft.winrm4j.client.wsman.Locale;
 
 public class WinRmClientBuilder {
     private static final java.util.Locale DEFAULT_LOCALE = java.util.Locale.US;
+    /**
+     * Timeout applied by default on client side for the opening of the socket (0 meaning infinite waiting).
+     */
+    private static final Long DEFAULT_CONNECTION_TIMEOUT = 0l;
+    /**
+     * Timeout applied by default on client side for the reading of the socket ({@code null} meaning automatically calculated from
+     * the{@link #operationTimeout} by adding to it one minute).
+     */
+    private static final Long DEFAULT_RECEIVE_TIMEOUT = null;
     private static final Long DEFAULT_OPERATION_TIMEOUT = 60l * 1000l;
     private static final int DEFAULT_RETRIES_FOR_CONNECTION_FAILURES = 1;
 
@@ -36,6 +46,7 @@ public class WinRmClientBuilder {
     protected Locale locale;
     protected long operationTimeout;
     protected Predicate<String> retryReceiveAfterOperationTimeout;
+    protected Long connectionTimeout;
     protected Long receiveTimeout;
     protected RetryPolicy failureRetryPolicy;
     protected Map<String, String> environment;
@@ -56,6 +67,8 @@ public class WinRmClientBuilder {
         locale(DEFAULT_LOCALE);
         operationTimeout(DEFAULT_OPERATION_TIMEOUT);
         retryReceiveAfterOperationTimeout(alwaysRetryReceiveAfterOperationTimeout());
+        connectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+        receiveTimeout(DEFAULT_RECEIVE_TIMEOUT);
         retriesForConnectionFailures(DEFAULT_RETRIES_FOR_CONNECTION_FAILURES);
     }
 
@@ -100,6 +113,30 @@ public class WinRmClientBuilder {
         this.operationTimeout = WinRmClient.checkNotNull(operationTimeout, "operationTimeout");
         return this;
     }
+
+   /**
+    * Timeout applied to connect the socket.
+    *
+    * @param connectionTimeout in milliseconds
+    *                         default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_TIMEOUT}
+    * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setConnectionTimeout-long-">HTTPClientPolicy#setConnectionTimeout</a>
+    */
+    public WinRmClientBuilder connectionTimeout(Long connectionTimeout) {
+        this.connectionTimeout = Objects.requireNonNull(connectionTimeout, "connectionTimeout");
+        return this;
+    }
+
+    /**
+     * Timeout applied to read the socket.
+     *
+     * @param receiveTimeout in milliseconds
+     *                         default value {@link WinRmClientBuilder#DEFAULT_RECEIVE_TIMEOUT}
+     * @see <a href="https://cxf.apache.org/javadoc/latest/org/apache/cxf/transports/http/configuration/HTTPClientPolicy.html#setReceiveTimeout-long-">HTTPClientPolicy#setReceiveTimeout</a>
+     */
+     public WinRmClientBuilder receiveTimeout(Long receiveTimeout) {
+         this.receiveTimeout = receiveTimeout;
+         return this;
+     }
 
     /**
      * @param retryReceiveAfterOperationTimeout define if a new Receive request will be send when the server returns

--- a/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
+++ b/winrm4j/src/main/java/io/cloudsoft/winrm4j/winrm/WinRmTool.java
@@ -47,6 +47,8 @@ public class WinRmTool {
     private Predicate<String> retryReceiveAfterOperationTimeout;
     private Integer retriesForConnectionFailures;
     private RetryPolicy failureRetryPolicy;
+    private Long connectionTimeout;
+    private Long receiveTimeout;
     private final boolean disableCertificateChecks;
     private final String workingDirectory;
     private final Map<String, String> environment;
@@ -231,6 +233,26 @@ public class WinRmTool {
         this.operationTimeout = operationTimeout;
     }
 
+	/**
+	 * Update connectionTimeout
+	 *
+	 * @param connectionTimeout in milliseconds
+	 *                         default value {@link WinRmClientBuilder#DEFAULT_CONNECTION_TIMEOUT}
+	 */
+	public void setConnectionTimeout(Long connectionTimeout) {
+		this.connectionTimeout = connectionTimeout;
+	}
+
+	/**
+	 * Update receiveTimeout
+	 *
+	 * @param receiveTimeout in milliseconds
+	 *                         default value {@link WinRmClientBuilder#DEFAULT_RECEIVE_TIMEOUT}
+	 */
+	public void setReceiveTimeout(Long receiveTimeout) {
+		this.receiveTimeout = receiveTimeout;
+	}
+
     public void setRetryReceiveAfterOperationTimeout(Predicate<String> retryReceiveAfterOperationTimeout) {
         this.retryReceiveAfterOperationTimeout = retryReceiveAfterOperationTimeout;
     }
@@ -270,6 +292,12 @@ public class WinRmTool {
         }
         if (retryReceiveAfterOperationTimeout != null) {
             builder.retryReceiveAfterOperationTimeout(retryReceiveAfterOperationTimeout);
+        }
+        if (connectionTimeout != null) {
+            builder.connectionTimeout(connectionTimeout);
+        }
+        if (receiveTimeout != null) {
+            builder.receiveTimeout(receiveTimeout);
         }
         if (username != null && password != null) {
             builder.credentials(domain, username, password);


### PR DESCRIPTION
Builds on PR #108 , rebasing that against master (hence the different commit id) and adding another commit on top. As per commit-message, changes/additions are:

    * Change default `connectionTimeout` to 30 seconds (to match previous behaviour).
    * Remove null-checks when primitive `long` is passed in.
    * Also make `connectionRequestTimeout` configurable.
