### PR TITLE
Upgrade to CXF 3.3.2

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -160,6 +160,28 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+              <!--
+                Don't include version number for bind, because otherwise it breaks with CXF 3.3.2 in Karaf 4.2.7.
+                In brief, if we include the version it means the jakarta.xml.bind-api bundle gets installed 
+                (which we don't want - that gives us two XMLRegistry classes on the classpath).
+                 
+                For more info:
+                 * See description of problem: https://lists.apache.org/thread.html/ead4351d187f7d7e7c257cb47f2490b3139d0de8d6fe15c43beea4d3%40%3Cdev.brooklyn.apache.org%3E
+                 * Pointer to solution from cxf mailing list: http://mail-archives.apache.org/mod_mbox/cxf-users/201912.mbox/%3c220874e1-37ca-1d15-4f79-17837cd73813@gmail.com%3e
+                 * Summary of conclusions: https://lists.apache.org/thread.html/f24c5833eb0ffda00021a57a606e143a4f5a2b7971df4e11406df1a6%40%3Cdev.brooklyn.apache.org%3E
+               -->
+              <Import-Package>
+                javax.xml.bind*;version=!,
+                *
+              </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,14 @@
     <surefire.version>2.19.1</surefire.version>
     <testng.version>6.9.10</testng.version>
     <guava.version>18.0</guava.version>
-    <cxf.version>3.2.8</cxf.version>
-    <cxf.java2ws.plugin.version>3.3.2</cxf.java2ws.plugin.version>
-    <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
-    <httpcomponents.httpasyncclient.version>4.1.4</httpcomponents.httpasyncclient.version>
-    <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
     <mockwebserver.version>3.5.0</mockwebserver.version>
+
+    <!-- Production -->
+    <cxf.version>3.3.2</cxf.version>
+    <cxf.java2ws.plugin.version>${cxf.version}</cxf.java2ws.plugin.version>
+    <httpcomponents.httpcore.version>4.4.11</httpcomponents.httpcore.version>
+    <httpcomponents.httpasyncclient.version>4.1.4</httpcomponents.httpasyncclient.version>
+    <httpcomponents.httpclient.version>4.5.8</httpcomponents.httpclient.version>
     <xmlunit.version>2.3.0</xmlunit.version>
   </properties>
 

--- a/winrm4j/pom.xml
+++ b/winrm4j/pom.xml
@@ -47,4 +47,32 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+              <!--
+                Don't include version number for bind, because otherwise it breaks with CXF 3.3.2 in Karaf 4.2.7.
+                In brief, if we include the version it means the jakarta.xml.bind-api bundle gets installed 
+                (which we don't want - that gives us two XMLRegistry classes on the classpath).
+                 
+                For more info:
+                 * See description of problem: https://lists.apache.org/thread.html/ead4351d187f7d7e7c257cb47f2490b3139d0de8d6fe15c43beea4d3%40%3Cdev.brooklyn.apache.org%3E
+                 * Pointer to solution from cxf mailing list: http://mail-archives.apache.org/mod_mbox/cxf-users/201912.mbox/%3c220874e1-37ca-1d15-4f79-17837cd73813@gmail.com%3e
+                 * Summary of conclusions: https://lists.apache.org/thread.html/f24c5833eb0ffda00021a57a606e143a4f5a2b7971df4e11406df1a6%40%3Cdev.brooklyn.apache.org%3E
+               -->
+              <Import-Package>
+                javax.xml.bind*;version=!,
+                *
+              </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
The fix is a bit weird! See this description, copied from the pom file comment:

Don't include version number for `javax.xml.bind*`, because otherwise it breaks with CXF 3.3.2 in Karaf 4.2.7.
In brief, if we include the version it means the jakarta.xml.bind-api bundle gets installed 
(which we don't want - that gives us two XMLRegistry classes on the classpath).
                 
For more info:
* See description of problem: https://lists.apache.org/thread.html/ead4351d187f7d7e7c257cb47f2490b3139d0de8d6fe15c43beea4d3%40%3Cdev.brooklyn.apache.org%3E
* Pointer to solution from cxf mailing list: http://mail-archives.apache.org/mod_mbox/cxf-users/201912.mbox/%3c220874e1-37ca-1d15-4f79-17837cd73813@gmail.com%3e
* Summary of conclusions: https://lists.apache.org/thread.html/f24c5833eb0ffda00021a57a606e143a4f5a2b7971df4e11406df1a6%40%3Cdev.brooklyn.apache.org%3E
