### PR TITLE
Add support for passing in a stringwriter

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
@@ -200,12 +200,6 @@ public class ShellCommand implements AutoCloseable {
                 }
             }
         }
-        try {
-            out.close();
-            err.close();
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     private void releaseCommand(String commandId) {


### PR DESCRIPTION
This would allow a calling process to "see" stdout / stderr as
they are produced.
Fix closing writer early - which wasn't an issue when write was a
stringwriter