### PR TITLE
Fix SLF4J dependency conflict

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -331,4 +331,15 @@
       </build>
     </profile>
   </profiles>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
     <commons-io.version>2.11.0</commons-io.version>
     <xmlunit.version>2.3.0</xmlunit.version>
+    <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
   <modules>

--- a/winrm4j/pom.xml
+++ b/winrm4j/pom.xml
@@ -81,4 +81,15 @@
     </plugins>
   </build>
 
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>


### PR DESCRIPTION
After getting started with this project I noticed a dependency conflict warning between the SLF4J version used by CXF and logback-classic. This PR resolves this by instructing both dependencies to use the latest 1.x version of SLF4J (currently 1.7.36)