### PR TITLE
Remove unused and deprecated import

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/WinRmClient.java
@@ -81,7 +81,6 @@ import io.cloudsoft.winrm4j.client.transfer.ResourceCreated;
 import io.cloudsoft.winrm4j.client.wsman.Locale;
 import io.cloudsoft.winrm4j.client.wsman.OptionSetType;
 import io.cloudsoft.winrm4j.client.wsman.OptionType;
-import sun.awt.image.ImageWatched.Link;
 
 /**
  * TODO confirm if commands can be called in parallel in one shell (probably not)!


### PR DESCRIPTION
sun.awt.image was encapsulated in Java9. As this import is not used we should be able to remove it.