### PR TITLE
Supply keepalive option for command/receive calls

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/ShellCommand.java
@@ -122,11 +122,15 @@ public class ShellCommand implements AutoCloseable {
             stream.setCommandId(commandId);
             stream.setValue("stdout stderr");
             receive.setDesiredStream(stream);
-
+            final OptionSetType optSetCmd = new OptionSetType();
+            OptionType optKeepalive = new OptionType();
+            optKeepalive.setName("WSMAN_CMDSHELL_OPTION_KEEPALIVE");
+            optKeepalive.setValue("TRUE");
+            optSetCmd.getOption().add(optKeepalive);
 
             try {
                 numberOfReceiveCalls++;
-                ReceiveResponse receiveResponse = winrm.receive(receive, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector);
+                ReceiveResponse receiveResponse = winrm.receive(receive, WinRmClient.RESOURCE_URI, WinRmClient.MAX_ENVELOPER_SIZE, operationTimeout, locale, shellSelector, optSetCmd);
                 getStreams(receiveResponse, out, err);
 
                 CommandStateType state = receiveResponse.getCommandState();

--- a/client/src/test/java/io/cloudsoft/winrm4j/client/RetryingProxyHandlerTest.java
+++ b/client/src/test/java/io/cloudsoft/winrm4j/client/RetryingProxyHandlerTest.java
@@ -171,8 +171,8 @@ public class RetryingProxyHandlerTest {
 		}
 
 		@Override
-		public ReceiveResponse receive(Receive receive, String resourceURI, int maxEnvelopeSize, String operationTimeout, Locale locale, SelectorSetType selectorSet) {
-			RecordedCall call = new RecordedCall("receive", Arrays.asList(receive, resourceURI, maxEnvelopeSize, operationTimeout, locale, selectorSet));
+		public ReceiveResponse receive(Receive receive, String resourceURI, int maxEnvelopeSize, String operationTimeout, Locale locale, SelectorSetType selectorSet, OptionSetType optionSet) {
+			RecordedCall call = new RecordedCall("receive", Arrays.asList(receive, resourceURI, maxEnvelopeSize, operationTimeout, locale, selectorSet, optionSet));
 			calls.add(call);
 			return (ReceiveResponse) handler.apply(call);
 		}

--- a/client/src/test/resources/recordings/win12.xml
+++ b/client/src/test/resources/recordings/win12.xml
@@ -209,6 +209,12 @@
               xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
             <ns2:Selector Name="ShellId">AF161CE1-3D3F-46B7-A101-800DD70639A9</ns2:Selector>
           </ns2:SelectorSet>
+          <ns2:OptionSet
+                  xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+                  xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                  xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WSMAN_CMDSHELL_OPTION_KEEPALIVE">TRUE</ns2:Option>
+          </ns2:OptionSet>
         </soap:Header>
         <soap:Body>
           <ns1:Receive

--- a/client/src/test/resources/recordings/win7.xml
+++ b/client/src/test/resources/recordings/win7.xml
@@ -195,6 +195,12 @@
               xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
             <ns2:Selector Name="ShellId">DDAD7559-3B88-44FA-890B-7FD87F86CB6C</ns2:Selector>
           </ns2:SelectorSet>
+          <ns2:OptionSet
+                  xmlns:ns1="http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+                  xmlns:ns2="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+                  xmlns:ns3="http://schemas.xmlsoap.org/ws/2004/09/transfer">
+            <ns2:Option Name="WSMAN_CMDSHELL_OPTION_KEEPALIVE">TRUE</ns2:Option>
+          </ns2:OptionSet>
         </soap:Header>
         <soap:Body>
           <ns1:Receive

--- a/service/src/main/java/io/cloudsoft/winrm4j/service/WinRm.java
+++ b/service/src/main/java/io/cloudsoft/winrm4j/service/WinRm.java
@@ -49,7 +49,9 @@ public class WinRm {
         @WebParam(name = "Locale", targetNamespace = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", header = true)
         Locale locale,
         @WebParam(name = "SelectorSet", targetNamespace = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", header = true)
-        SelectorSetType selectorSet
+        SelectorSetType selectorSet,
+        @WebParam(name = "OptionSet", targetNamespace = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd", header = true)
+        OptionSetType optionSet
     ) {
         return null;
     }


### PR DESCRIPTION
As recommended by Microsoft documentation, this adds WSMAN_CMDSHELL_OPTION_KEEPALIVE=TRUE for command's `Receive` messages.

Ref https://docs.microsoft.com/en-us/openspecs/windows_protocols/MS-WSMV/83309079-a09e-41ec-ad54-f608c2fec355