### PR TITLE
Fix missing wrapped closing in case closing encrypt interceptor

### DIFF
--- a/client/src/main/java/io/cloudsoft/winrm4j/client/encryption/SignAndEncryptOutInterceptor.java
+++ b/client/src/main/java/io/cloudsoft/winrm4j/client/encryption/SignAndEncryptOutInterceptor.java
@@ -81,8 +81,11 @@ public class SignAndEncryptOutInterceptor extends AbstractPhaseInterceptor<Messa
             currentStream = new NullOutputStream();
 
             if (wrapped!=null) {
-                processAndShip(wrapped);
-                wrapped.close();
+                try {
+                    processAndShip(wrapped);
+                } finally {
+                    wrapped.close();
+                }
             } else {
                 LOG.warn("No stream for writing encrypted message to");
             }


### PR DESCRIPTION
If the closing fails -- technically: if `processAndShip()` fails -- then the actual wrapped stream will not be closed anymore resulting in a resource leak and non-closed connection.